### PR TITLE
Enable inference when no constant forcings are used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Keep it human-readable, your future self will thank you!
 
 ## [Unreleased]
 ### Added
+- Fix: Enable inference when no constant forcings are used
 
 ### Changed
 

--- a/src/anemoi/inference/checkpoint/metadata/version_0_2_0.py
+++ b/src/anemoi/inference/checkpoint/metadata/version_0_2_0.py
@@ -133,7 +133,7 @@ class ZarrRequest(DataRequest):
 
     @property
     def param_step_sfc_pairs(self):
-        return self.request["param_step"].get("sfc", [])
+        return self.request.get("param_step", {}).get("sfc", [])
 
     @property
     def variables_with_nans(self):

--- a/src/anemoi/inference/checkpoint/metadata/version_0_2_0.py
+++ b/src/anemoi/inference/checkpoint/metadata/version_0_2_0.py
@@ -1,10 +1,10 @@
 # (C) Copyright 2023 European Centre for Medium-Range Weather Forecasts.
-# (C) Copyright 2024 Deutscher Wetterdienst.
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-# In applying this licence, the above institution do not waive the privileges
-# and immunities granted to it by virtue of its status as an intergovernmental
-# organisation  nor does it submit to any jurisdiction.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
 
 import logging
 from functools import cached_property

--- a/src/anemoi/inference/checkpoint/metadata/version_0_2_0.py
+++ b/src/anemoi/inference/checkpoint/metadata/version_0_2_0.py
@@ -1,10 +1,10 @@
 # (C) Copyright 2023 European Centre for Medium-Range Weather Forecasts.
+# (C) Copyright 2024 Deutscher Wetterdienst.
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-# In applying this licence, ECMWF does not waive the privileges and immunities
-# granted to it by virtue of its status as an intergovernmental organisation
-# nor does it submit to any jurisdiction.
-
+# In applying this licence, the above institution do not waive the privileges
+# and immunities granted to it by virtue of its status as an intergovernmental
+# organisation  nor does it submit to any jurisdiction.
 
 import logging
 from functools import cached_property

--- a/src/anemoi/inference/runner.py
+++ b/src/anemoi/inference/runner.py
@@ -112,7 +112,7 @@ class Runner:
         input_fields = input_fields.sel(**self.checkpoint.select)
         input_fields = input_fields.order_by(**self.checkpoint.order_by)
 
-        number_of_grid_points = len(input_fields[0].grid_points()[0])
+        number_of_grid_points = len(input_fields[0].values)
 
         LOGGER.info("Loading input: %d fields (lagged=%d)", len(input_fields), len(self.lagged))
 
@@ -236,9 +236,10 @@ class Runner:
 
         input_tensor_numpy[:, prognostic_input_mask] = input_fields_numpy[:, prognostic_data_from_retrieved_fields_mask]
 
-        input_tensor_numpy[:, constant_from_input_mask] = input_fields_numpy[
-            :, constant_data_from_retrieved_fields_mask
-        ]
+        if len(constant_from_input_mask) > 0:
+            input_tensor_numpy[:, constant_from_input_mask] = input_fields_numpy[
+                :, constant_data_from_retrieved_fields_mask
+            ]
 
         constants = forcing_and_constants(
             source=input_fields[:1],
@@ -249,13 +250,14 @@ class Runner:
         for i in range(len(self.lagged)):
             input_tensor_numpy[i, computed_constant_mask] = constants
 
-        for i in range(len(self.lagged)):
-            forcings = forcing_and_constants(
-                source=input_fields[:1],
-                param=self.checkpoint.computed_forcings,
-                date=start_datetime + datetime.timedelta(hours=self.lagged[i]),
-            )
-            input_tensor_numpy[i, computed_forcing_mask] = forcings
+        if len(constant_from_input_mask) > 0:
+            for i in range(len(self.lagged)):
+                forcings = forcing_and_constants(
+                    source=input_fields[:1],
+                    param=self.checkpoint.computed_forcings,
+                    date=start_datetime + datetime.timedelta(hours=self.lagged[i]),
+                )
+                input_tensor_numpy[i, computed_forcing_mask] = forcings
 
         LOGGER.info("Input tensor shape: %s", input_tensor_numpy.shape)
 
@@ -405,7 +407,8 @@ class Runner:
             # Update dynamic tensor for next iteration
             input_tensor_torch = input_tensor_torch.roll(-1, dims=1)
             input_tensor_torch[:, -1, :, prognostic_input_mask] = prognostic_fields
-            input_tensor_torch[:, -1, :, computed_forcing_mask] = forcing
+            if computed_forcing_mask:
+                input_tensor_torch[:, -1, :, computed_forcing_mask] = forcing
 
             # progress_callback(i)
 

--- a/src/anemoi/inference/runner.py
+++ b/src/anemoi/inference/runner.py
@@ -1,9 +1,10 @@
 # (C) Copyright 2024 European Centre for Medium-Range Weather Forecasts.
+# (C) Copyright 2024 Deutscher Wetterdienst.
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-# In applying this licence, ECMWF does not waive the privileges and immunities
-# granted to it by virtue of its status as an intergovernmental organisation
-# nor does it submit to any jurisdiction.
+# In applying this licence, the above institution do not waive the privileges
+# and immunities granted to it by virtue of its status as an intergovernmental
+# organisation  nor does it submit to any jurisdiction.
 
 
 import datetime

--- a/src/anemoi/inference/runner.py
+++ b/src/anemoi/inference/runner.py
@@ -1,10 +1,9 @@
 # (C) Copyright 2024 European Centre for Medium-Range Weather Forecasts.
-# (C) Copyright 2024 Deutscher Wetterdienst.
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-# In applying this licence, the above institution do not waive the privileges
-# and immunities granted to it by virtue of its status as an intergovernmental
-# organisation  nor does it submit to any jurisdiction.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
 
 
 import datetime


### PR DESCRIPTION
Inference failed when no constant forcings were used in the training.

The error message related to the fact, that an empty list in `computed_forcing_mask` can't be used as an index.