### PR TITLE
fix dataset path

### DIFF
--- a/src/anemoi/inference/inputs/dataset.py
+++ b/src/anemoi/inference/inputs/dataset.py
@@ -9,7 +9,6 @@
 
 
 import logging
-import os
 
 import numpy as np
 from earthkit.data.utils.dates import to_datetime

--- a/src/anemoi/inference/inputs/dataset.py
+++ b/src/anemoi/inference/inputs/dataset.py
@@ -16,7 +16,6 @@ from earthkit.data.utils.dates import to_datetime
 
 from . import Input
 
-
 LOG = logging.getLogger(__name__)
 
 

--- a/src/anemoi/inference/inputs/dataset.py
+++ b/src/anemoi/inference/inputs/dataset.py
@@ -9,11 +9,13 @@
 
 
 import logging
+import os
 
 import numpy as np
 from earthkit.data.utils.dates import to_datetime
 
 from . import Input
+
 
 LOG = logging.getLogger(__name__)
 
@@ -38,7 +40,10 @@ class DatasetInput(Input):
             LOG.warning("open_dataset(*%s, **%s)", args, kwargs)
 
         if isinstance(kwargs, str):
-            self.ds = open_dataset(kwargs)
+            try:
+                self.ds = open_dataset(os.path.splitext(os.path.basename(kwargs))[0])
+            except ValueError:
+                self.ds = open_dataset(kwargs)
         else:
             self.ds = open_dataset(*args, **kwargs)
 

--- a/src/anemoi/inference/inputs/dataset.py
+++ b/src/anemoi/inference/inputs/dataset.py
@@ -39,7 +39,7 @@ class DatasetInput(Input):
             LOG.warning("open_dataset(*%s, **%s)", args, kwargs)
 
         if isinstance(kwargs, str):
-            self.ds = open_dataset(os.path.splitext(os.path.basename(kwargs))[0])
+            self.ds = open_dataset(kwargs)
         else:
             self.ds = open_dataset(*args, **kwargs)
 


### PR DESCRIPTION
The calling of the dataset path was broken, since .zarr was stripped. Furthermore it is more convenient to keep the full dataset path as set in the checkpoint as the default. In the fix here the path as read from the checkpoint is directly fed to anemoi-datasets `open_dataset`. 