### PR TITLE
add raw output

### DIFF
--- a/src/anemoi/inference/commands/run.py
+++ b/src/anemoi/inference/commands/run.py
@@ -20,6 +20,7 @@ from ..inputs.dataset import DatasetInput
 from ..inputs.gribfile import GribFileInput
 from ..inputs.icon import IconInput
 from ..outputs.gribfile import GribFileOutput
+from ..outputs.raw import RawOutput
 from ..outputs.printer import PrinterOutput
 from ..runners.cutout import CutoutRunner
 from ..runners.default import DefaultRunner
@@ -94,7 +95,12 @@ class RunCmd(Command):
             input = context.mars_input(use_grib_paramid=config.use_grib_paramid)
 
         if config.output is not None:
-            output = GribFileOutput(context, config.output, allow_nans=config.allow_nans)
+            if config.output_type == 'grib':
+                output = GribFileOutput(context, config.output, allow_nans=config.allow_nans)
+            elif config.output_type == 'raw':
+                output = RawOutput(config.output)
+            else:
+                raise ValueError("You must set output_typ to either 'grib' or 'raw'. Other formats not yet supported.")
         else:
             output = PrinterOutput(context)
 

--- a/src/anemoi/inference/commands/run.py
+++ b/src/anemoi/inference/commands/run.py
@@ -20,8 +20,8 @@ from ..inputs.dataset import DatasetInput
 from ..inputs.gribfile import GribFileInput
 from ..inputs.icon import IconInput
 from ..outputs.gribfile import GribFileOutput
-from ..outputs.raw import RawOutput
 from ..outputs.printer import PrinterOutput
+from ..outputs.raw import RawOutput
 from ..runners.cutout import CutoutRunner
 from ..runners.default import DefaultRunner
 from . import Command
@@ -95,9 +95,9 @@ class RunCmd(Command):
             input = context.mars_input(use_grib_paramid=config.use_grib_paramid)
 
         if config.output is not None:
-            if config.output_type == 'grib':
+            if config.output_type == "grib":
                 output = GribFileOutput(context, config.output, allow_nans=config.allow_nans)
-            elif config.output_type == 'raw':
+            elif config.output_type == "raw":
                 output = RawOutput(config.output)
             else:
                 raise ValueError("You must set output_typ to either 'grib' or 'raw'. Other formats not yet supported.")

--- a/src/anemoi/inference/config.py
+++ b/src/anemoi/inference/config.py
@@ -44,6 +44,8 @@ class Configuration(BaseModel):
     input: str | None = None
     output: str | None = None
 
+    output_type: str = 'grib'
+
     device: str = "cuda"
     """The device on which the model should run. This can be "cpu", "cuda" or any other value supported by PyTorch."""
 

--- a/src/anemoi/inference/config.py
+++ b/src/anemoi/inference/config.py
@@ -44,7 +44,7 @@ class Configuration(BaseModel):
     input: str | None = None
     output: str | None = None
 
-    output_type: str = 'grib'
+    output_type: str = "grib"
 
     device: str = "cuda"
     """The device on which the model should run. This can be "cpu", "cuda" or any other value supported by PyTorch."""

--- a/src/anemoi/inference/outputs/raw.py
+++ b/src/anemoi/inference/outputs/raw.py
@@ -1,0 +1,38 @@
+# (C) Copyright 2024 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import datetime
+import logging
+import os
+
+import numpy as np
+
+from . import Output
+
+LOG = logging.getLogger(__name__)
+
+
+
+class RawOutput(Output):
+    """_summary_"""
+    def __init__(self, path):
+        self.path = path
+
+    def write_initial_state(self, state):
+        self.write_state(state)
+
+    def write_state(self, state):
+        os.makedirs(self.path, exist_ok=True)
+        fn_state = f"{self.path}/{state['date'].strftime("%Y%m%d_%H")}"
+        restate = {f"field_{key}" : val for key, val in state['fields'].items() }
+        restate['longitudes'] = state['longitudes']
+        restate['latitudes'] = state['latitudes']
+        np.savez_compressed(fn_state,**restate)
+
+        

--- a/src/anemoi/inference/outputs/raw.py
+++ b/src/anemoi/inference/outputs/raw.py
@@ -7,7 +7,6 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-import datetime
 import logging
 import os
 
@@ -18,9 +17,9 @@ from . import Output
 LOG = logging.getLogger(__name__)
 
 
-
 class RawOutput(Output):
     """_summary_"""
+
     def __init__(self, path):
         self.path = path
 
@@ -30,9 +29,7 @@ class RawOutput(Output):
     def write_state(self, state):
         os.makedirs(self.path, exist_ok=True)
         fn_state = f"{self.path}/{state['date'].strftime("%Y%m%d_%H")}"
-        restate = {f"field_{key}" : val for key, val in state['fields'].items() }
-        restate['longitudes'] = state['longitudes']
-        restate['latitudes'] = state['latitudes']
-        np.savez_compressed(fn_state,**restate)
-
-        
+        restate = {f"field_{key}": val for key, val in state["fields"].items()}
+        restate["longitudes"] = state["longitudes"]
+        restate["latitudes"] = state["latitudes"]
+        np.savez_compressed(fn_state, **restate)


### PR DESCRIPTION
Basic output, saving the dictionary with numpy arrays as .npz, should work for all input types. Raw output is turned on by setting `output_type: raw` in the config, in that case `output: path` sets the directory where the output will be stored. If `output_type` is not set in the config, but `output` is specified, grib output is assumed, as to be backwards compatible.

Example config:

output: first-experiment
output_type: raw
checkpoint: inference-last.ckpt
date: 2007-10-03
dataset: True
lead_time: 6h