### PR TITLE
remove prog fields variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Keep it human-readable, your future self will thank you!
 ### Changed
 - Fix: diagnostics bug when fields are non-accumulated, remove diagnostics from mars request [#18](https://github.com/ecmwf/anemoi-inference/pull/18)
 - ci: updated workflows on PR and releases to use reusable actions
+- removed a variable 'prognostic\_fields' to save GPU memory
 
 ### Removed
 - climetlab

--- a/src/anemoi/inference/runner.py
+++ b/src/anemoi/inference/runner.py
@@ -493,9 +493,6 @@ class Runner:
                         )
 
             # Next step
-
-            prognostic_fields = y_pred[..., prognostic_output_mask]
-
             # Compute new forcing
 
             forcing = forcing_and_constants(
@@ -508,7 +505,7 @@ class Runner:
 
             # Update dynamic tensor for next iteration
             input_tensor_torch = input_tensor_torch.roll(-1, dims=1)
-            input_tensor_torch[:, -1, :, prognostic_input_mask] = prognostic_fields
+            input_tensor_torch[:, -1, :, prognostic_input_mask] = y_pred[..., prognostic_output_mask]
             if computed_forcing_mask:
                 input_tensor_torch[:, -1, :, computed_forcing_mask] = forcing
 


### PR DESCRIPTION
Not quite a bugfix or a feature, just a little change which can save some memory

```python
- prognostic_fields = y_pred[..., prognostic_output_mask]
...
- input_tensor_torch[:, -1, :, prognostic_input_mask] = prognostic_fields
+ input_tensor_torch[:, -1, :, prognostic_input_mask] = y_pred[..., prognostic_output_mask]
```

Currently we create a `prognostic_fields` variable and then assign it to `input_tensor_torch` a few lines later. Nothing happens to `prognostic_fields` or `y_pred` in-between, so i guess this variable is just for readability? 

The issue is this prog fields memory is never freed, so, after the first iteration we carry around this `prognostic_fields` variable. At 9km resolution, this is 2.2GB of memory (~3% of an H100s memory). We can save this memory by removing the variable and just using `y_pred` directly.

I have annotated the memory usage of 5 steps of inference at 9km below. The relevant part is this blue `anemoi_inference/src/anemoi/inference/runner/py:503` block which appears after the first step. This is the prog fields variable, and it is repeated for all subsequent steps.

<img width="1506" alt="Screenshot 2024-11-19 at 11 46 20" src="https://github.com/user-attachments/assets/b45591c0-c335-4682-8fc9-c9e3c82b04f6">

I compared the output between this version and the original and saw no major difference. But I'm Interested in feedback, it is a relatively minor memory gain but every little helps. And maybe there's future plans which require `prognostic_fields` to be its own variable?