### PR TITLE
add model parallel for inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Keep it human-readable, your future self will thank you!
 - Add anemoi-transform link to documentation
 - Add support for unstructured grids
 - Add CONTRIBUTORS.md file (#36)
+- Added ability to run inference over multiple GPUs [#55](https://github.com/ecmwf/anemoi-inference/pull/55)
 
 ### Changed
 


### PR DESCRIPTION
Lets you run inference over multiple GPUs. 

All credit goes to @mishooax . This is his implementation, I just added it to anemoi inference

I compared output for n320 1024c running on 1 GPU vs 4 GPUs and it seems to match.

With this I was able to run 9km inference over 4 nodes with 4 40GB a100s per node. 

I would like feedback about how the input tensor is read and how the output tensor is written. Currently all ranks read the input and only rank 0 writes output. Also, at the moment when you run there is lots of duplicated logging 

Unfortunately you have to use slurm to launch an inference job on multiple GPUs (as opposed to anemoi training which supports launching interactive jobs with multiple gpus like `anemoi-training train hardware.num_gpus_per_node=<num_gpus>`). I tried launching with 'torchrun' but it didnt work. Happy to look into this more though

If you are running over multiple nodes you need to add these lines to your slurm batch script
```bash
MASTER_ADDR=$(scontrol show hostname $SLURM_NODELIST | head -n 1)
export MASTER_ADDR=$(nslookup $MASTER_ADDR | grep -oP '(?<=Address: ).*')
```
If you're running over a single node, `localhost` is used as the address.