### PR TITLE
Improved output of initial state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,9 @@ Keep it human-readable, your future self will thank you!
 - Add CONTRIBUTORS.md file (#36)
 
 ### Changed
+- Change `write_initial_state` default value to `true`
 - Raw output of initial state contains only values at initial time
-- Changed default naming of raw output
+- Change default naming of raw output
 - Add cos_solar_zenith_angle to list of known forcings
 - Add missing classes in checkpoint handling
 - Rename Condition to State [#24](https://github.com/ecmwf/anemoi-inference/pull/24)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Keep it human-readable, your future self will thank you!
 ## [Unreleased]
 
 ### Added
-- Add initial state output in netcdf format 
+- Add initial state output in netcdf format
 - Fix: Enable inference when no constant forcings are used
 - Add anemoi-transform link to documentation
 - Add support for unstructured grids

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,15 @@ Keep it human-readable, your future self will thank you!
 ## [Unreleased]
 
 ### Added
-
+- Add initial state output in netcdf format 
 - Fix: Enable inference when no constant forcings are used
 - Add anemoi-transform link to documentation
 - Add support for unstructured grids
 - Add CONTRIBUTORS.md file (#36)
 
 ### Changed
-
+- Raw output of initial state contains only values at initial time
+- Changed default naming of raw output
 - Add cos_solar_zenith_angle to list of known forcings
 - Add missing classes in checkpoint handling
 - Rename Condition to State [#24](https://github.com/ecmwf/anemoi-inference/pull/24)

--- a/docs/configs/top-level.rst
+++ b/docs/configs/top-level.rst
@@ -57,7 +57,7 @@ write_initial_state:
 
 The ``write_initial_state`` option specifies whether to write the
 initial state to the output (i.e. "step zero" of the forecast). Default
-is ``false``.
+is ``true``.
 
 allow_nans:
 ===========

--- a/src/anemoi/inference/config.py
+++ b/src/anemoi/inference/config.py
@@ -68,7 +68,7 @@ class Configuration(BaseModel):
     use_grib_paramid: bool = False
     """If True, the runner will use the grib parameter ID when generating MARS requests."""
 
-    write_initial_state: bool = False
+    write_initial_state: bool = True
     """Wether to write the initial state to the output file. If the model is multi-step, only fields at the forecast reference date are
     written."""
 

--- a/src/anemoi/inference/output.py
+++ b/src/anemoi/inference/output.py
@@ -6,7 +6,6 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 #
-import copy
 from abc import ABC
 from abc import abstractmethod
 
@@ -31,7 +30,8 @@ class Output(ABC):
 
     def reduce(self, state):
         """Creates new state which is projection of original state on the last step in the multi-steps dimension."""
-        reduced_state = copy.deepcopy(state)
+        reduced_state = state.copy()
+        reduced_state['fields'] = {}
         for field, values in state["fields"].items():
             reduced_state["fields"][field] = values[-1, :]
         return reduced_state

--- a/src/anemoi/inference/output.py
+++ b/src/anemoi/inference/output.py
@@ -8,7 +8,7 @@
 #
 from abc import ABC
 from abc import abstractmethod
-
+import copy
 
 class Output(ABC):
     """_summary_"""

--- a/src/anemoi/inference/output.py
+++ b/src/anemoi/inference/output.py
@@ -28,5 +28,12 @@ class Output(ABC):
     def write_state(self, state):
         pass
 
+    def reduce(self, state):
+        """Creates new state which is projection of original state on the last step in the multi-steps dimension. """
+        reduced_state = copy.deepcopy(state)
+        for field, values in state['fields'].items():
+            reduced_state['fields'][field] = values[-1,:]
+        return reduced_state
+
     def close(self):
         pass

--- a/src/anemoi/inference/output.py
+++ b/src/anemoi/inference/output.py
@@ -6,9 +6,10 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 #
+import copy
 from abc import ABC
 from abc import abstractmethod
-import copy
+
 
 class Output(ABC):
     """_summary_"""
@@ -29,10 +30,10 @@ class Output(ABC):
         pass
 
     def reduce(self, state):
-        """Creates new state which is projection of original state on the last step in the multi-steps dimension. """
+        """Creates new state which is projection of original state on the last step in the multi-steps dimension."""
         reduced_state = copy.deepcopy(state)
-        for field, values in state['fields'].items():
-            reduced_state['fields'][field] = values[-1,:]
+        for field, values in state["fields"].items():
+            reduced_state["fields"][field] = values[-1, :]
         return reduced_state
 
     def close(self):

--- a/src/anemoi/inference/output.py
+++ b/src/anemoi/inference/output.py
@@ -31,7 +31,7 @@ class Output(ABC):
     def reduce(self, state):
         """Creates new state which is projection of original state on the last step in the multi-steps dimension."""
         reduced_state = state.copy()
-        reduced_state['fields'] = {}
+        reduced_state["fields"] = {}
         for field, values in state["fields"].items():
             reduced_state["fields"][field] = values[-1, :]
         return reduced_state

--- a/src/anemoi/inference/outputs/netcdf.py
+++ b/src/anemoi/inference/outputs/netcdf.py
@@ -64,7 +64,7 @@ class NetCDFOutput(Output):
         self.time_dim = self.ncfile.createDimension("time", time)
         self.time_var = self.ncfile.createVariable("time", "i4", ("time",), **compression)
 
-        self.time_var.units = "seconds since {0}".format(self.context.reference_date)
+        self.time_var.units = "seconds since {0}".format(self.reference_date)
         self.time_var.long_name = "time"
         self.time_var.calendar = "gregorian"
 

--- a/src/anemoi/inference/outputs/netcdf.py
+++ b/src/anemoi/inference/outputs/netcdf.py
@@ -54,12 +54,12 @@ class NetCDFOutput(Output):
         values = len(state["latitudes"])
 
         time = 0
-        self.reference_date=state["date"]
+        self.reference_date = state["date"]
         if hasattr(self.context, "time_step") and hasattr(self.context, "lead_time"):
             time = self.context.lead_time // self.context.time_step
         if hasattr(self.context, "reference_date"):
             self.reference_date = self.context.reference_date
-            
+
         self.values_dim = self.ncfile.createDimension("values", values)
         self.time_dim = self.ncfile.createDimension("time", time)
         self.time_var = self.ncfile.createVariable("time", "i4", ("time",), **compression)
@@ -107,7 +107,7 @@ class NetCDFOutput(Output):
     def write_initial_state(self, state):
         reduced_state = self.reduce(state)
         self.write_state(reduced_state)
-        
+
     def write_state(self, state):
         self._init(state)
 

--- a/src/anemoi/inference/outputs/netcdf.py
+++ b/src/anemoi/inference/outputs/netcdf.py
@@ -53,9 +53,15 @@ class NetCDFOutput(Output):
 
         values = len(state["latitudes"])
 
+        time = 0
+        self.reference_date=state["date"]
+        if hasattr(self.context, "time_step") and hasattr(self.context, "lead_time"):
+            time = self.context.lead_time // self.context.time_step
+        if hasattr(self.context, "reference_date"):
+            self.reference_date = self.context.reference_date
+            
         self.values_dim = self.ncfile.createDimension("values", values)
-
-        self.time_dim = self.ncfile.createDimension("time", self.context.lead_time // self.context.time_step)
+        self.time_dim = self.ncfile.createDimension("time", time)
         self.time_var = self.ncfile.createVariable("time", "i4", ("time",), **compression)
 
         self.time_var.units = "seconds since {0}".format(self.context.reference_date)
@@ -99,12 +105,13 @@ class NetCDFOutput(Output):
         return self.ncfile
 
     def write_initial_state(self, state):
-        LOG.warning("NetCDFOutput: Writing of initial state is not supported.")
-
+        reduced_state = self.reduce(state)
+        self.write_state(reduced_state)
+        
     def write_state(self, state):
         self._init(state)
 
-        step = state["date"] - self.context.reference_date
+        step = state["date"] - self.reference_date
         self.time_var[self.n] = step.total_seconds()
 
         for name, value in state["fields"].items():

--- a/src/anemoi/inference/outputs/plot.py
+++ b/src/anemoi/inference/outputs/plot.py
@@ -49,7 +49,8 @@ class PlotOutput(Output):
                 self.variables = [self.variables]
 
     def write_initial_state(self, state):
-        self.write_state(state)
+        reduced_state = self.reduce(state)
+        self.write_state(reduced_state)
 
     def write_state(self, state):
         import cartopy.crs as ccrs
@@ -65,9 +66,6 @@ class PlotOutput(Output):
 
             if self.variables is not all and name not in self.variables:
                 continue
-
-            if values.ndim == 2:
-                values = values[-1]
 
             _, ax = plt.subplots(subplot_kw={"projection": ccrs.PlateCarree()})
             ax.coastlines()

--- a/src/anemoi/inference/outputs/raw.py
+++ b/src/anemoi/inference/outputs/raw.py
@@ -24,9 +24,14 @@ LOG = logging.getLogger(__name__)
 class RawOutput(Output):
     """_summary_"""
 
-    def __init__(self, context, path):
+    def __init__(self, context, path,
+                 template="{date}.npz",
+                 strftime="%Y%m%d%H%M%S",
+                 ):
         super().__init__(context)
         self.path = path
+        self.template=template
+        self.strftime=strftime
 
     def __repr__(self):
         return f"RawOutput({self.path})"

--- a/src/anemoi/inference/outputs/raw.py
+++ b/src/anemoi/inference/outputs/raw.py
@@ -24,14 +24,17 @@ LOG = logging.getLogger(__name__)
 class RawOutput(Output):
     """_summary_"""
 
-    def __init__(self, context, path,
-                 template="{date}.npz",
-                 strftime="%Y%m%d%H%M%S",
-                 ):
+    def __init__(
+        self,
+        context,
+        path,
+        template="{date}.npz",
+        strftime="%Y%m%d%H%M%S",
+    ):
         super().__init__(context)
         self.path = path
-        self.template=template
-        self.strftime=strftime
+        self.template = template
+        self.strftime = strftime
 
     def __repr__(self):
         return f"RawOutput({self.path})"

--- a/src/anemoi/inference/outputs/raw.py
+++ b/src/anemoi/inference/outputs/raw.py
@@ -32,12 +32,14 @@ class RawOutput(Output):
         return f"RawOutput({self.path})"
 
     def write_initial_state(self, state):
-        self.write_state(state)
+        reduced_state = self.reduce(state)
+        self.write_state(reduced_state)
 
     def write_state(self, state):
         os.makedirs(self.path, exist_ok=True)
-        fn_state = f"{self.path}/{state['date'].strftime('%Y%m%d_%H')}"
+        date = state["date"].strftime(self.strftime)
+        fn_state = f"{self.path}/{self.template.format(date=date)}"
         restate = {f"field_{key}": val for key, val in state["fields"].items()}
-        restate["longitudes"] = state["longitudes"]
-        restate["latitudes"] = state["latitudes"]
+        for key in ["date", "longitudes", "latitudes"]:
+            restate[key] = np.array(state[key], dtype=str)
         np.savez_compressed(fn_state, **restate)


### PR DESCRIPTION
This PR closes #61 and #48. 
A new function `reduce()` is added to the `Output` class, which projects a state to the last step in the multi-step dimension.

This function is then used to define `write_initial_state()` as a combination of `reduce()` and `write_state()` for the netcdf, raw and plot output.

The naming of the raw output is brought in line with the naming of the plot output.

The default `write_initial_state` config setting is now `true`.

<!-- readthedocs-preview anemoi-inference start -->
----
📚 Documentation preview 📚: https://anemoi-inference--62.org.readthedocs.build/en/62/

<!-- readthedocs-preview anemoi-inference end -->