### PR TITLE
Make frozendict picklable

### DIFF
--- a/src/anemoi/inference/metadata.py
+++ b/src/anemoi/inference/metadata.py
@@ -13,6 +13,7 @@ import os
 import warnings
 from collections import defaultdict
 from functools import cached_property
+from types import MappingProxyType as frozendict
 from typing import Literal
 
 import numpy as np
@@ -35,15 +36,6 @@ def _remove_full_paths(x):
     if isinstance(x, str):
         return os.path.splitext(os.path.basename(x))[0]
     return x
-
-
-class frozendict(dict):
-    def __deepcopy__(self, memo):
-        # As this is a frozendict, we can return the same object
-        return self
-
-    def __setitem__(self, key, value):
-        raise TypeError("frozendict is immutable")
 
 
 class Metadata(PatchMixin, LegacyMixin):


### PR DESCRIPTION
Replaces frozendict implementation by existing stdlib thing which behaves more or less the same, but coops with pickle

I've tested like `d = frozendict({'a': 4})` and `d['a'] == 4` and `d['a'] = 5 # raises` and `del d['a'] # raises` and `d['b'] = 7 # raises`. Are there any other cases of interest?

(ftr I put `no changelog` here, this should have no outwardly visible effect)