### PR TITLE
Output archive requests json with no indent by default

### DIFF
--- a/src/anemoi/inference/outputs/gribfile.py
+++ b/src/anemoi/inference/outputs/gribfile.py
@@ -117,6 +117,7 @@ class GribFileOutput(GribOutput):
         path = self.archive_requests["path"]
         extra = self.archive_requests.get("extra", {})
         patch = self.archive_requests.get("patch", {})
+        indent = self.archive_requests.get("indent", None)
 
         def _patch(r):
             if self.context.config.use_grib_paramid:
@@ -147,4 +148,4 @@ class GribFileOutput(GribOutput):
                 request.update(extra)
                 requests.append(request)
 
-            json.dump(requests, f, indent=4)
+            json.dump(requests, f, indent=indent)


### PR DESCRIPTION
Ouput the archive json with no indent by default, so it is only on 1 line. This makes it easier to handle the file afterwards, like concat into a jsonl file.