### PR TITLE
Add support for downloading models from huggingface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Keep it human-readable, your future self will thank you!
 - Add support for unstructured grids
 - Add CONTRIBUTORS.md file (#36)
 - Add sanetise command
+- Add support for huggingface
 
 ### Changed
 - Change `write_initial_state` default value to `true`

--- a/docs/configs/top-level.rst
+++ b/docs/configs/top-level.rst
@@ -11,12 +11,19 @@ The following options control the inference process:
 checkpoint:
 ===========
 
-The only compulsory option is ``checkpoint``, which specifies the path
-to the checkpoint file.
+The only compulsory option is ``checkpoint``, which specifies the checkpoint file. 
+It can be a path to a local file, or a huggingface config.
 
 .. code:: yaml
 
    checkpoint: /path/to/checkpoint.ckpt
+
+.. code:: yaml
+
+   checkpoint: 
+      huggingface:
+         repo_id: "ecmwf/aifs-single"
+         filename: "aifs_single_v0.2.1.ckpt"
 
 device:
 =======

--- a/docs/configs/top-level.rst
+++ b/docs/configs/top-level.rst
@@ -11,8 +11,9 @@ The following options control the inference process:
 checkpoint:
 ===========
 
-The only compulsory option is ``checkpoint``, which specifies the checkpoint file. 
-It can be a path to a local file, or a huggingface config.
+The only compulsory option is ``checkpoint``, which specifies the
+checkpoint file. It can be a path to a local file, or a huggingface
+config.
 
 .. code:: yaml
 
@@ -20,7 +21,7 @@ It can be a path to a local file, or a huggingface config.
 
 .. code:: yaml
 
-   checkpoint: 
+   checkpoint:
       huggingface:
          repo_id: "ecmwf/aifs-single"
          filename: "aifs_single_v0.2.1.ckpt"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,8 @@ optional-dependencies.docs = [
 ]
 
 optional-dependencies.plugin = [ "ai-models>=0.7", "tqdm" ]
+optional-dependencies.huggingface = [ "huggingface_hub" ]
+
 
 optional-dependencies.tests = [ "anemoi-datasets[all]", "hypothesis", "pytest" ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,10 +68,9 @@ optional-dependencies.docs = [
   "sphinx-rtd-theme",
 ]
 
+optional-dependencies.huggingface = [ "huggingface-hub" ]
+
 optional-dependencies.plugin = [ "ai-models>=0.7", "tqdm" ]
-optional-dependencies.huggingface = [ "huggingface_hub" ]
-
-
 optional-dependencies.tests = [ "anemoi-datasets[all]", "hypothesis", "pytest" ]
 
 urls.Documentation = "https://anemoi-inference.readthedocs.io/"

--- a/src/anemoi/inference/checkpoint.py
+++ b/src/anemoi/inference/checkpoint.py
@@ -20,6 +20,7 @@ from .metadata import Metadata
 
 LOG = logging.getLogger(__name__)
 
+
 def _download_huggingfacehub(huggingface_config):
     """Download model from huggingface"""
     try:
@@ -30,6 +31,7 @@ def _download_huggingfacehub(huggingface_config):
     config_path = hf_hub_download(**huggingface_config)
     return config_path
 
+
 class Checkpoint:
     """Represents an inference checkpoint."""
 
@@ -38,7 +40,7 @@ class Checkpoint:
 
     def __repr__(self):
         return f"Checkpoint({self.path})"
-    
+
     @cached_property
     def path(self):
         import json
@@ -51,11 +53,10 @@ class Checkpoint:
         if isinstance(self._model, str):
             return self._model
         elif isinstance(self._model, dict):
-            if 'huggingface' in self._model:
-                return _download_huggingfacehub(self._model['huggingface'])
+            if "huggingface" in self._model:
+                return _download_huggingfacehub(self._model["huggingface"])
             pass
         raise TypeError(f"Cannot parse model path: {self._model}. It must be a path or dict")
-
 
     @cached_property
     def _metadata(self):

--- a/src/anemoi/inference/config.py
+++ b/src/anemoi/inference/config.py
@@ -12,7 +12,9 @@ from __future__ import annotations
 import datetime
 import logging
 import os
-from typing import Dict, Literal, Any
+from typing import Any
+from typing import Dict
+from typing import Literal
 
 import yaml
 from pydantic import BaseModel
@@ -27,7 +29,7 @@ class Configuration(BaseModel):
 
     description: str | None = None
 
-    checkpoint: str | Dict[Literal['huggingface'], Dict[str, Any]]
+    checkpoint: str | Dict[Literal["huggingface"], Dict[str, Any]]
     """A path to an Anemoi checkpoint file."""
 
     date: str | int | datetime.datetime | None = None

--- a/src/anemoi/inference/config.py
+++ b/src/anemoi/inference/config.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import datetime
 import logging
 import os
-from typing import Dict
+from typing import Dict, Literal, Any
 
 import yaml
 from pydantic import BaseModel
@@ -27,8 +27,8 @@ class Configuration(BaseModel):
 
     description: str | None = None
 
-    checkpoint: str
-    """A path an Anemoi checkpoint file."""
+    checkpoint: str | Dict[Literal['huggingface'], Dict[str, Any]]
+    """A path to an Anemoi checkpoint file."""
 
     date: str | int | datetime.datetime | None = None
     """The starting date for the forecast. If not provided, the date will depend on the selected Input object. If a string, it is parsed by :func:`anemoi.utils.dates.as_datetime`.


### PR DESCRIPTION
# Add support for huggingface

Models will be downloaded from huggingface through specification in the config.

```yaml
checkpoint:
  huggingface:
    repo_id: "ecmwf/aifs-single"
    filename: "aifs_single_v0.2.1.ckpt"
```

<!-- readthedocs-preview anemoi-inference start -->
----
📚 Documentation preview 📚: https://anemoi-inference--75.org.readthedocs.build/en/75/

<!-- readthedocs-preview anemoi-inference end -->