### PR TITLE
Write output coordinates of RawOutput as floats

### DIFF
--- a/src/anemoi/inference/outputs/raw.py
+++ b/src/anemoi/inference/outputs/raw.py
@@ -53,4 +53,3 @@ class RawOutput(Output):
         for key in ["latitudes", "longitudes"]:
             restate[key] = np.array(state[key])
         np.savez_compressed(fn_state, **restate)
-

--- a/src/anemoi/inference/outputs/raw.py
+++ b/src/anemoi/inference/outputs/raw.py
@@ -48,6 +48,9 @@ class RawOutput(Output):
         date = state["date"].strftime(self.strftime)
         fn_state = f"{self.path}/{self.template.format(date=date)}"
         restate = {f"field_{key}": val for key, val in state["fields"].items()}
-        for key in ["date", "longitudes", "latitudes"]:
+        for key in ["date"]:
             restate[key] = np.array(state[key], dtype=str)
+        for key in ["latitudes", "longitudes"]:
+            restate[key] = np.array(state[key])
         np.savez_compressed(fn_state, **restate)
+


### PR DESCRIPTION
# Purpose
Ensure that coordinates are written to raw output as floats instead of strings as it currently happens.