### PR TITLE
feat(retrieve): Use input grib as target

### DIFF
--- a/src/anemoi/inference/commands/retrieve.py
+++ b/src/anemoi/inference/commands/retrieve.py
@@ -28,7 +28,7 @@ class RetrieveCmd(Command):
         command_parser.add_argument("config", type=str, help="Path to checkpoint")
         command_parser.add_argument("--defaults", action="append", help="Sources of default values.")
         command_parser.add_argument("--date", type=str, help="Date")
-        command_parser.add_argument("--output", type=str, help="Output file")
+        command_parser.add_argument("--output", type=str, default="/dev/stdout", help="Output file")
         command_parser.add_argument("--staging-dates", type=str, help="Path to a file with staging dates")
         command_parser.add_argument("--extra", action="append", help="Additional request values. Can be repeated")
         command_parser.add_argument("overrides", nargs="*", help="Overrides.")

--- a/src/anemoi/inference/commands/retrieve.py
+++ b/src/anemoi/inference/commands/retrieve.py
@@ -9,6 +9,7 @@
 
 
 import json
+import sys
 
 from earthkit.data.utils.dates import to_datetime
 
@@ -29,7 +30,7 @@ class RetrieveCmd(Command):
         command_parser.add_argument("config", type=str, help="Path to checkpoint")
         command_parser.add_argument("--defaults", action="append", help="Sources of default values.")
         command_parser.add_argument("--date", type=str, help="Date")
-        command_parser.add_argument("--output", type=str, default="/dev/stdout", help="Output file")
+        command_parser.add_argument("--output", type=str, default=None, help="Output file")
         command_parser.add_argument("--staging-dates", type=str, help="Path to a file with staging dates")
         command_parser.add_argument("--extra", action="append", help="Additional request values. Can be repeated")
         command_parser.add_argument("overrides", nargs="*", help="Overrides.")
@@ -48,6 +49,7 @@ class RetrieveCmd(Command):
 
         extra = postproc(grid, area)
 
+        # so that the user does not need to pass --extra target=path when the input file is already in the config
         input = runner.create_input()
         if isinstance(input, GribInput):
             extra["target"] = input.path
@@ -75,8 +77,15 @@ class RetrieveCmd(Command):
             r.update(extra)
             requests.append(r)
 
-        with open(args.output, "w") as f:
+        if args.output and args.output != "-":
+            f = open(args.output, "w")
+        else:
+            f = sys.stdout
+
+        try:
             json.dump(requests, f, indent=4)
+        finally:
+            f.close()
 
 
 command = RetrieveCmd

--- a/src/anemoi/inference/commands/retrieve.py
+++ b/src/anemoi/inference/commands/retrieve.py
@@ -78,14 +78,11 @@ class RetrieveCmd(Command):
             requests.append(r)
 
         if args.output and args.output != "-":
-            f = open(args.output, "w")
-        else:
-            f = sys.stdout
+            with open(args.output, "w") as f:
+                json.dump(requests, f, indent=4)
+            return
 
-        try:
-            json.dump(requests, f, indent=4)
-        finally:
-            f.close()
+        json.dump(requests, sys.stdout, indent=4)
 
 
 command = RetrieveCmd

--- a/src/anemoi/inference/commands/retrieve.py
+++ b/src/anemoi/inference/commands/retrieve.py
@@ -13,6 +13,7 @@ import json
 from earthkit.data.utils.dates import to_datetime
 
 from ..config import load_config
+from ..inputs.grib import GribInput
 from ..inputs.mars import postproc
 from ..runners.default import DefaultRunner
 from . import Command
@@ -47,11 +48,9 @@ class RetrieveCmd(Command):
 
         extra = postproc(grid, area)
 
-        if isinstance(config.input, dict):
-            if input := config.input.get("grib"):
-                if isinstance(input, dict):
-                    input = input["path"]
-                extra["target"] = input
+        input = runner.create_input()
+        if isinstance(input, GribInput):
+            extra["target"] = input.path
 
         for r in args.extra or []:
             k, v = r.split("=")

--- a/src/anemoi/inference/commands/retrieve.py
+++ b/src/anemoi/inference/commands/retrieve.py
@@ -48,8 +48,10 @@ class RetrieveCmd(Command):
         extra = postproc(grid, area)
 
         if isinstance(config.input, dict):
-            if path := config.input.get("grib"):
-                extra["target"] = path
+            if input := config.input.get("grib"):
+                if isinstance(input, dict):
+                    input = input["path"]
+                extra["target"] = input
 
         for r in args.extra or []:
             k, v = r.split("=")

--- a/src/anemoi/inference/commands/retrieve.py
+++ b/src/anemoi/inference/commands/retrieve.py
@@ -47,6 +47,10 @@ class RetrieveCmd(Command):
 
         extra = postproc(grid, area)
 
+        if isinstance(config.input, dict):
+            if path := config.input.get("grib"):
+                extra["target"] = path
+
         for r in args.extra or []:
             k, v = r.split("=")
             extra[k] = v


### PR DESCRIPTION
If the config contains an input grib, the retrieve command will use that are the target in the generated mars request. 
Also make the default output stdout.

config.yaml:
```yaml
input:
  grib: input.grib
checkpoint: model.ckpt
```

```
anemoi-inference retrieve config.yaml --date 20240101T00:00:00
```
will have target=input.grib

Target can still be overwritten by passing `--extra target=anotherinput.grib`