### PR TITLE
Support models with unconnected nodes removed from input (LAM)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Keep it human-readable, your future self will thank you!
 ## [Unreleased]
 
 ### Added
+- Add support for models with unconnected nodes dropped from input [#95](https://github.com/ecmwf/anemoi-inference/pull/95).
+- Change trigger for boundary forcings [#95](https://github.com/ecmwf/anemoi-inference/pull/95).
+- Add support for automatic loading of anemoi-datasets of more general type [#95](https://github.com/ecmwf/anemoi-inference/pull/95).
 - Add initial state output in netcdf format
 - Fix: Enable inference when no constant forcings are used
 - Add anemoi-transform link to documentation

--- a/src/anemoi/inference/checkpoint.py
+++ b/src/anemoi/inference/checkpoint.py
@@ -312,7 +312,7 @@ class Checkpoint:
 
     @cached_property
     def _supporting_arrays(self):
-        return self._metadata.supporting_arrays
+        return self._metadata._supporting_arrays
 
     @property
     def name(self):

--- a/src/anemoi/inference/forcings.py
+++ b/src/anemoi/inference/forcings.py
@@ -136,8 +136,10 @@ class BoundaryForcings(Forcings):
         self.variables_mask = variables_mask
         assert isinstance(input, DatasetInput), "Currently only boundary forcings from dataset supported."
         self.input = input
-        num_lam, num_other = input.ds.grids
-        self.spatial_mask = np.array([False] * num_lam + [True] * num_other, dtype=bool)
+        if "output_mask" in context.checkpoint._supporting_arrays:
+            self.spatial_mask= ~context.checkpoint.load_supporting_array("output_mask")
+        else:
+            self.spatial_mask=np.array([False] * len(input["latitudes"]) , dtype=bool)
         self.kinds = dict(retrieved=True)  # Used for debugging
 
     def __repr__(self):

--- a/src/anemoi/inference/forcings.py
+++ b/src/anemoi/inference/forcings.py
@@ -137,9 +137,9 @@ class BoundaryForcings(Forcings):
         assert isinstance(input, DatasetInput), "Currently only boundary forcings from dataset supported."
         self.input = input
         if "output_mask" in context.checkpoint._supporting_arrays:
-            self.spatial_mask= ~context.checkpoint.load_supporting_array("output_mask")
+            self.spatial_mask = ~context.checkpoint.load_supporting_array("output_mask")
         else:
-            self.spatial_mask=np.array([False] * len(input["latitudes"]) , dtype=bool)
+            self.spatial_mask = np.array([False] * len(input["latitudes"]), dtype=bool)
         self.kinds = dict(retrieved=True)  # Used for debugging
 
     def __repr__(self):

--- a/src/anemoi/inference/inputs/dataset.py
+++ b/src/anemoi/inference/inputs/dataset.py
@@ -99,6 +99,8 @@ class DatasetInput(Input):
         data = np.squeeze(data, axis=2)
         # Reorder the dimensions to (variable, date, values)
         data = np.swapaxes(data, 0, 1)
+        # apply reduction to `grid_indices`
+        data=data[...,self.grid_indices]
         return data
 
     def _load_dates(self, dates):

--- a/src/anemoi/inference/inputs/dataset.py
+++ b/src/anemoi/inference/inputs/dataset.py
@@ -29,7 +29,7 @@ class DatasetInput(Input):
     def __init__(self, context, args, kwargs):
         super().__init__(context)
 
-        grid_indices=kwargs.pop("grid_indices", None)
+        grid_indices = kwargs.pop("grid_indices", None)
 
         self.args, self.kwargs = args, kwargs
         if context.verbosity > 0:
@@ -47,7 +47,6 @@ class DatasetInput(Input):
 
         self.grid_indices = slice(None) if grid_indices is None else grid_indices
 
-
     @cached_property
     def ds(self):
         from anemoi.datasets import open_dataset
@@ -62,8 +61,8 @@ class DatasetInput(Input):
             raise ValueError("`date` must be provided")
 
         date = to_datetime(date)
-        latitudes=self.ds.latitudes
-        longitudes=self.ds.longitudes
+        latitudes = self.ds.latitudes
+        longitudes = self.ds.longitudes
 
         input_state = dict(
             date=date,
@@ -86,7 +85,7 @@ class DatasetInput(Input):
                 continue
             # Squeeze the data to remove the ensemble dimension
             values = np.squeeze(data[:, i], axis=1)
-            fields[variable] = values[:,self.grid_indices]
+            fields[variable] = values[:, self.grid_indices]
 
         return input_state
 
@@ -100,7 +99,7 @@ class DatasetInput(Input):
         # Reorder the dimensions to (variable, date, values)
         data = np.swapaxes(data, 0, 1)
         # apply reduction to `grid_indices`
-        data=data[...,self.grid_indices]
+        data = data[..., self.grid_indices]
         return data
 
     def _load_dates(self, dates):

--- a/src/anemoi/inference/metadata.py
+++ b/src/anemoi/inference/metadata.py
@@ -139,6 +139,8 @@ class Metadata(PatchMixin, LegacyMixin):
     @cached_property
     def number_of_grid_points(self):
         """Return the number of grid points per fields"""
+        if "grid_indices" in self._supporting_arrays:
+            return len(self.load_supporting_array("grid_indices"))
         try:
             return self._metadata.dataset.shape[-1]
         except AttributeError:

--- a/src/anemoi/inference/metadata.py
+++ b/src/anemoi/inference/metadata.py
@@ -718,9 +718,7 @@ class Metadata(PatchMixin, LegacyMixin):
 
         result = []
 
-        output_mask = self._config_model.get("output_mask", None)
-        if output_mask is not None:
-            assert output_mask == "cutout", "Currently only cutout as output mask supported."
+        if "output_mask" in self._supporting_arrays:
             result.append(
                 context.create_boundary_forcings(
                     self.prognostic_variables,

--- a/src/anemoi/inference/metadata.py
+++ b/src/anemoi/inference/metadata.py
@@ -512,14 +512,12 @@ class Metadata(PatchMixin, LegacyMixin):
                         _find(y)
 
             if isinstance(x, dict):
-                if "dataset" in x:
+                if "dataset" in x  and isinstance(x["dataset"], str):
                     result.append(x["dataset"])
 
                 for k, v in x.items():
                     _find(v)
-
         _find(self._config.dataloader.training.dataset)
-
         return result
 
     def open_dataset_args_kwargs(self, *, use_original_paths, from_dataloader=None):

--- a/src/anemoi/inference/metadata.py
+++ b/src/anemoi/inference/metadata.py
@@ -512,11 +512,12 @@ class Metadata(PatchMixin, LegacyMixin):
                         _find(y)
 
             if isinstance(x, dict):
-                if "dataset" in x  and isinstance(x["dataset"], str):
+                if "dataset" in x and isinstance(x["dataset"], str):
                     result.append(x["dataset"])
 
                 for k, v in x.items():
                     _find(v)
+
         _find(self._config.dataloader.training.dataset)
         return result
 


### PR DESCRIPTION
This PR adds support for inference from checkpoints created with models where unconnected nodes have been dropped from the input grid, see [anemoi-training #171](https://github.com/ecmwf/anemoi-training/pull/171). For the moment the functionality is restricted to inference taking an anemoi-dataset as input.

The indices of those gridpoints in the dataset that remain as input for the model are stored in the checkpoint as the supporting array `grid_indices`.  The current implementation is such that if this supporting array is present in the checkpoint then the input is automatically reduced to those points with indices listed in `grid_indices`. 

A small update of the boundary forcing is also needed, the mask used is now (the negation of) the `output_mask` that can be found in relevant checkpoints. 

This addresses #87 

Update: also added small fix to allow for automatic loading of datasets with more complicated configurations where `sub_dictionary['dataset']` is not necessarily a string, e.g. of the type

```yaml
dataset:
    - dataset:
        cutout:
          - dataset: ${hardware.paths.data}/${hardware.files.lam_dataset} 
          - dataset: ${hardware.paths.data}/${hardware.files.forcing_dataset}
        adjust: all
    - dataset:
        cutout:
          - dataset: ${hardware.paths.data}/${hardware.files.lam_z_dataset}
          - dataset: ${hardware.paths.data}/${hardware.files.forcing_dataset}
        adjust: all
``` 