### PR TITLE
Deep merge user config with defaults

### DIFF
--- a/src/anemoi/inference/config.py
+++ b/src/anemoi/inference/config.py
@@ -19,6 +19,7 @@ from typing import Optional
 from typing import Union
 
 import yaml
+from anemoi.utils.config import _merge_dicts
 from pydantic import BaseModel
 
 LOG = logging.getLogger(__name__)
@@ -110,7 +111,8 @@ def load_config(path, overrides, defaults=None, Configuration=Configuration):
 
     # Load the configuration
     with open(path) as f:
-        config.update(yaml.safe_load(f))
+        user_config = yaml.safe_load(f)
+        _merge_dicts(config, user_config)
 
     # Apply overrides
     for override in overrides:


### PR DESCRIPTION
When merging default config with the user config, use a deep key-by-key merge instead of just updating the top level keys. If a key exists in both configs, the user config will take priority.

Example:

 `anemoi-inference run config.yaml --defaults defaults.yaml `

```yaml
# config.yaml
input: mars
output:
  grib:
    path: file.grib
    check_encoding: true
```


```yaml
# defaults.yaml
checkpoint: checkpoint.ckpt
output:
  grib:
    encoding:
      some_key: 123
    check_encoding: false
```

Result:
```yaml
checkpoint: checkpoint.ckpt
input: mars
output:
  grib:
    path: file.grib
    check_encoding: true
    encoding:
      some_key: 123
```

