### PR TITLE
feat(output): allow selecting variables for GRIB output

### DIFF
--- a/src/anemoi/inference/outputs/gribfile.py
+++ b/src/anemoi/inference/outputs/gribfile.py
@@ -92,6 +92,7 @@ class GribFileOutput(GribOutput):
         modifiers=None,
         output_frequency=None,
         write_initial_state=None,
+        variables=None,
         **kwargs,
     ):
         super().__init__(
@@ -103,6 +104,7 @@ class GribFileOutput(GribOutput):
             modifiers=modifiers,
             output_frequency=output_frequency,
             write_initial_state=write_initial_state,
+            variables=variables,
         )
         self.path = path
         self.output = ekd.new_grib_output(self.path, split_output=True, **kwargs)


### PR DESCRIPTION
# Purpose
Allow users to specify a list of variables (a subset of the variables in the state fields) that they want to include in an output GRIB file. 

# Code changes
- added a `variable` keyword to the corresponding classes. When not provided, all fields are written to output. 
- also made a bugfix on L262 of `grib.py` so it uses the correct param (based on the original local definitions used when creating the anemoi dataset), e.g. in our case `T_2M` would need to be used instead of `2t`. 