### PR TITLE
feat: parallel inference without slurm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,6 @@ Keep it human-readable, your future self will thank you!
 - Fix `__version__` import in init
 - use earthkit-data 0.11.2
 - Fix SimpleRunner
-- Inference can be run in parallel on 1 node without slurm [#121](https://github.com/ecmwf/anemoi-inference/pull/121)
 
 ### Removed
 - ci: turn off hpc workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Keep it human-readable, your future self will thank you!
 - Fix `__version__` import in init
 - use earthkit-data 0.11.2
 - Fix SimpleRunner
+- Inference can be run in parallel on 1 node without slurm [#121](https://github.com/ecmwf/anemoi-inference/pull/121)
 
 ### Removed
 - ci: turn off hpc workflow

--- a/docs/parallel.rst
+++ b/docs/parallel.rst
@@ -7,19 +7,26 @@ single GPU, you can run Anemoi-Inference in parallel across multiple
 GPUs.
 
 You have two options to launch parallel inference:
- * Launch without Slurm. This allows you to run inference across multiple GPUs **on a single node**. 
- * Launch via Slurm. Slurm is needed to run inference **across multiple nodes**.
+   -  Launch without Slurm. This allows you to run inference across
+      multiple GPUs **on a single node**.
+   -  Launch via Slurm. Slurm is needed to run inference **across
+      multiple nodes**.
 
 ***************
  Configuration
 ***************
 
-To run in parallel, you must add ':code:`runner:parallel`' to your inference
-config file. 
-If you are running in parallel without Slurm, you must also add a ':code:`world_size: num_gpus`' field. This informs Anemoi-Inference how many GPUs you want to run across. It cannot be greater then the number of GPUs on a single node.
+To run in parallel, you must add '``runner:parallel``' to your inference
+config file. If you are running in parallel without Slurm, you must also
+add a '``world_size: num_gpus``' field. This informs Anemoi-Inference
+how many GPUs you want to run across. It cannot be greater then the
+number of GPUs on a single node.
 
 .. note::
-        If you are launching parallel inference via Slurm, ':code:`world_size`' will be ignored in favour of the ':code:`SLURM_NTASKS`' environment variable.
+
+   If you are launching parallel inference via Slurm, '``world_size``'
+   will be ignored in favour of the '``SLURM_NTASKS``' environment
+   variable.
 
 .. code:: yaml
 
@@ -36,7 +43,9 @@ If you are running in parallel without Slurm, you must also add a ':code:`world_
  Running inference in parallel without Slurm
 *********************************************
 
-Once you have added ':code:`runner:parallel`' and ':code:`world_size: num_gpus`' to your config file, you can launch parallel inference by calling ':code:`anemoi-inferece run config.yaml`' as normal. 
+Once you have added '``runner:parallel``' and '``world_size: num_gpus``'
+to your config file, you can launch parallel inference by calling
+'``anemoi-inferece run config.yaml``' as normal.
 
 ******************************************
  Running inference in parallel with Slurm
@@ -60,8 +69,8 @@ job across 4 GPUs with SLURM.
 
 .. warning::
 
-   If you specify ':code:`runner:parallel`' but you don't launch with
-   ':code:`srun`', your anemoi-inference job may hang as only 1 process will
+   If you specify '``runner:parallel``' but you don't launch with
+   '``srun``', your anemoi-inference job may hang as only 1 process will
    be launched.
 
 .. note::

--- a/docs/parallel.rst
+++ b/docs/parallel.rst
@@ -16,11 +16,10 @@ You have two options to launch parallel inference:
  Prerequisites
 ***************
 
-Parallel inference requires a certain minimum version of Anemoi-models >=
-v0.4.2. If this breaks your
-checkpoints, you could cherry-pick `the relevant PR
-<https://github.com/ecmwf/anemoi-core/pull/77>`_ into your old version
-of Anemoi-Models.
+Parallel inference requires a certain minimum version of Anemoi-models
+>= v0.4.2. If this breaks your checkpoints, you could cherry-pick `the
+relevant PR <https://github.com/ecmwf/anemoi-core/pull/77>`_ into your
+old version of Anemoi-Models.
 
 ***************
  Configuration

--- a/docs/parallel.rst
+++ b/docs/parallel.rst
@@ -16,9 +16,8 @@ You have two options to launch parallel inference:
  Prerequisites
 ***************
 
-Parallel inference requires a certain minimum version of Anemoi-models >
-v0.4.1. The minimum commit required is
-'``db587fe5b350a98cfb95b90ede327e6ec6d470da``'. If this breaks your
+Parallel inference requires a certain minimum version of Anemoi-models >=
+v0.4.2. If this breaks your
 checkpoints, you could cherry-pick `the relevant PR
 <https://github.com/ecmwf/anemoi-core/pull/77>`_ into your old version
 of Anemoi-Models.

--- a/docs/parallel.rst
+++ b/docs/parallel.rst
@@ -13,6 +13,17 @@ You have two options to launch parallel inference:
       multiple nodes**.
 
 ***************
+ Prerequisites
+***************
+
+Parallel inference requires a certain minimum version of Anemoi-models >
+v0.4.1. The minimum commit required is
+'``db587fe5b350a98cfb95b90ede327e6ec6d470da``'. If this breaks your
+checkpoints, you could cherry-pick `the relevant PR
+<https://github.com/ecmwf/anemoi-core/pull/77>`_ into your old version
+of Anemoi-Models.
+
+***************
  Configuration
 ***************
 

--- a/docs/parallel.rst
+++ b/docs/parallel.rst
@@ -6,34 +6,44 @@ If the memory requirements of your model are too large to fit within a
 single GPU, you can run Anemoi-Inference in parallel across multiple
 GPUs.
 
-Parallel inference requires SLURM to launch the parallel processes and
-to determine information about your network environment. If SLURM is not
-available to you, please create an issue on the Anemoi-Inference github
-page `here <https://github.com/ecmwf/anemoi-inference/issues>`_.
+You have two options to launch parallel inference:
+ * Launch without Slurm. This allows you to run inference across multiple GPUs **on a single node**. 
+ * Launch via Slurm. Slurm is needed to run inference **across multiple nodes**.
 
 ***************
  Configuration
 ***************
 
-To run in parallel, you must add '`runner:parallel`' to your inference
-config file.
+To run in parallel, you must add ':code:`runner:parallel`' to your inference
+config file. 
+If you are running in parallel without Slurm, you must also add a ':code:`world_size: num_gpus`' field. This informs Anemoi-Inference how many GPUs you want to run across. It cannot be greater then the number of GPUs on a single node.
+
+.. note::
+        If you are launching parallel inference via Slurm, ':code:`world_size`' will be ignored in favour of the ':code:`SLURM_NTASKS`' environment variable.
 
 .. code:: yaml
 
    checkpoint: /path/to/inference-last.ckpt
    lead_time: 60
    runner: parallel
+   world_size: 4 #Only required if running parallel inference without Slurm
    input:
      grib: /path/to/input.grib
    output:
      grib: /path/to/output.grib
 
-*******************************
- Running inference in parallel
-*******************************
+*********************************************
+ Running inference in parallel without Slurm
+*********************************************
+
+Once you have added ':code:`runner:parallel`' and ':code:`world_size: num_gpus`' to your config file, you can launch parallel inference by calling ':code:`anemoi-inferece run config.yaml`' as normal. 
+
+******************************************
+ Running inference in parallel with Slurm
+******************************************
 
 Below is an example SLURM batch script to launch a parallel inference
-job across 4 GPUs.
+job across 4 GPUs with SLURM.
 
 .. code:: bash
 
@@ -50,8 +60,8 @@ job across 4 GPUs.
 
 .. warning::
 
-   If you specify '`runner:parallel`' but you don't launch with
-   '`srun`', your anemoi-inference job may hang as only 1 process will
+   If you specify ':code:`runner:parallel`' but you don't launch with
+   ':code:`srun`', your anemoi-inference job may hang as only 1 process will
    be launched.
 
 .. note::

--- a/src/anemoi/inference/commands/run.py
+++ b/src/anemoi/inference/commands/run.py
@@ -17,11 +17,7 @@ from . import Command
 
 LOG = logging.getLogger(__name__)
 
-
-# need to abstract this for parallel inference
-def _run(config, pid=0):
-    runner = create_runner(config, pid)
-
+def _run(runner, config):
     input = runner.create_input()
     output = runner.create_output()
 
@@ -52,7 +48,9 @@ class RunCmd(Command):
         if config.description is not None:
             LOG.info("%s", config.description)
 
-        _run(config)
+        runner = create_runner(config)
+
+        _run(runner, config)
 
 
 command = RunCmd

--- a/src/anemoi/inference/commands/run.py
+++ b/src/anemoi/inference/commands/run.py
@@ -18,6 +18,23 @@ from . import Command
 LOG = logging.getLogger(__name__)
 
 
+#need to abstract this for parallel inference
+def _run(config, pid=0):
+    runner = create_runner(config, pid)
+
+    input = runner.create_input()
+    output = runner.create_output()
+
+    input_state = input.create_input_state(date=config.date)
+
+    output.write_initial_state(input_state)
+
+    for state in runner.run(input_state=input_state, lead_time=config.lead_time):
+        output.write_state(state)
+
+    output.close()
+
+
 class RunCmd(Command):
     """Run inference from a config yaml file."""
 
@@ -35,19 +52,6 @@ class RunCmd(Command):
         if config.description is not None:
             LOG.info("%s", config.description)
 
-        runner = create_runner(config)
-
-        input = runner.create_input()
-        output = runner.create_output()
-
-        input_state = input.create_input_state(date=config.date)
-
-        output.write_initial_state(input_state)
-
-        for state in runner.run(input_state=input_state, lead_time=config.lead_time):
-            output.write_state(state)
-
-        output.close()
-
+        _run(config)
 
 command = RunCmd

--- a/src/anemoi/inference/commands/run.py
+++ b/src/anemoi/inference/commands/run.py
@@ -17,6 +17,7 @@ from . import Command
 
 LOG = logging.getLogger(__name__)
 
+
 def _run(runner, config):
     input = runner.create_input()
     output = runner.create_output()

--- a/src/anemoi/inference/config.py
+++ b/src/anemoi/inference/config.py
@@ -53,6 +53,12 @@ class Configuration(BaseModel):
     verbosity: int = 0
     """The verbosity level of the runner. This can be 0 (default), 1, 2 or 3."""
 
+    pid: Optional[int] = 0
+    """ Process id, used for parallel inference without SLURM """
+
+    world_size: Optional[int] = 1
+    """ Number of parallel processes, used for parallel inference without SLURM """
+
     report_error: bool = False
     """If True, the runner list the training versions of the packages in case of error."""
 

--- a/src/anemoi/inference/config.py
+++ b/src/anemoi/inference/config.py
@@ -53,9 +53,6 @@ class Configuration(BaseModel):
     verbosity: int = 0
     """The verbosity level of the runner. This can be 0 (default), 1, 2 or 3."""
 
-    pid: Optional[int] = 0
-    """ Process id, used for parallel inference without SLURM. This should not be set by the user"""
-
     world_size: Optional[int] = 1
     """ Number of parallel processes, used for parallel inference without SLURM """
 

--- a/src/anemoi/inference/config.py
+++ b/src/anemoi/inference/config.py
@@ -54,7 +54,7 @@ class Configuration(BaseModel):
     """The verbosity level of the runner. This can be 0 (default), 1, 2 or 3."""
 
     pid: Optional[int] = 0
-    """ Process id, used for parallel inference without SLURM """
+    """ Process id, used for parallel inference without SLURM. This should not be set by the user"""
 
     world_size: Optional[int] = 1
     """ Number of parallel processes, used for parallel inference without SLURM """

--- a/src/anemoi/inference/runners/__init__.py
+++ b/src/anemoi/inference/runners/__init__.py
@@ -11,5 +11,5 @@ from anemoi.utils.registry import Registry
 runner_registry = Registry(__name__)
 
 
-def create_runner(config, *kwargs):
-    return runner_registry.create(config.runner, config, *kwargs)
+def create_runner(config, *args):
+    return runner_registry.create(config.runner, config, *args)

--- a/src/anemoi/inference/runners/__init__.py
+++ b/src/anemoi/inference/runners/__init__.py
@@ -11,5 +11,5 @@ from anemoi.utils.registry import Registry
 runner_registry = Registry(__name__)
 
 
-def create_runner(config, *args):
-    return runner_registry.create(config.runner, config, *args)
+def create_runner(config, **kwargs):
+    return runner_registry.create(config.runner, config, **kwargs)

--- a/src/anemoi/inference/runners/__init__.py
+++ b/src/anemoi/inference/runners/__init__.py
@@ -11,5 +11,5 @@ from anemoi.utils.registry import Registry
 runner_registry = Registry(__name__)
 
 
-def create_runner(config):
-    return runner_registry.create(config.runner, config)
+def create_runner(config, *kwargs):
+    return runner_registry.create(config.runner, config, *kwargs)

--- a/src/anemoi/inference/runners/parallel.py
+++ b/src/anemoi/inference/runners/parallel.py
@@ -81,7 +81,9 @@ class ParallelRunner(DefaultRunner):
             try:
                 return model.predict_step(input_tensor_torch, self.model_comm_group)
             except TypeError as err:
-                LOG.error("Please upgrade to a newer version of anemoi-models to use parallel inference")
+                LOG.error(
+                    "Please upgrade to a newer version of anemoi-models (at least commit 'db587fe5b350a98cfb95b90ede327e6ec6d470da') to use parallel inference. If updating breaks your checkpoints, you can try reverting to your original version of anemoi-models and cherry-picking 'https://github.com/ecmwf/anemoi-core/pull/77'"
+                )
                 raise err
 
     def create_output(self):

--- a/src/anemoi/inference/runners/parallel.py
+++ b/src/anemoi/inference/runners/parallel.py
@@ -20,15 +20,17 @@ import torch.distributed as dist
 
 from ..commands.run import _run
 from ..outputs import create_output
+from ..runners import create_runner
 from . import runner_registry
 from .default import DefaultRunner
-from ..runners import create_runner
 
 LOG = logging.getLogger(__name__)
+
 
 def create_parallel_runner(config, pid):
     runner = create_runner(config, pid)
     _run(runner, config)
+
 
 @runner_registry.register("parallel")
 class ParallelRunner(DefaultRunner):
@@ -134,7 +136,7 @@ class ParallelRunner(DefaultRunner):
         import torch.multiprocessing as mp
 
         mp.set_start_method("spawn")
-        config=self.config
+        config = self.config
         for pid in range(1, num_procs):
             mp.Process(target=create_parallel_runner, args=(config, pid)).start()
 

--- a/src/anemoi/inference/runners/parallel.py
+++ b/src/anemoi/inference/runners/parallel.py
@@ -65,7 +65,7 @@ class ParallelRunner(DefaultRunner):
                 return model.predict_step(input_tensor_torch, self.model_comm_group)
             except TypeError as err:
                 LOG.error(
-                    "Please upgrade to a newer version of anemoi-models (at least commit 'db587fe5b350a98cfb95b90ede327e6ec6d470da') to use parallel inference. If updating breaks your checkpoints, you can try reverting to your original version of anemoi-models and cherry-picking 'https://github.com/ecmwf/anemoi-core/pull/77'"
+                    "Please upgrade to a newer version of anemoi-models (at least version v0.4.2) to use parallel inference. If updating breaks your checkpoints, you can try reverting to your original version of anemoi-models and cherry-picking 'https://github.com/ecmwf/anemoi-core/pull/77'"
                 )
                 raise err
 

--- a/src/anemoi/inference/runners/parallel.py
+++ b/src/anemoi/inference/runners/parallel.py
@@ -28,7 +28,7 @@ LOG = logging.getLogger(__name__)
 
 
 def create_parallel_runner(config, pid):
-    runner = create_runner(config, pid)
+    runner = create_runner(config, pid=pid)
     _run(runner, config)
 
 

--- a/src/anemoi/inference/runners/parallel.py
+++ b/src/anemoi/inference/runners/parallel.py
@@ -107,9 +107,9 @@ class ParallelRunner(DefaultRunner):
     def __srun_used(self):
         """returns true if anemoi-inference was launched with srun"""
 
-        #from pytorch lightning
+        # from pytorch lightning
         # https://github.com/Lightning-AI/pytorch-lightning/blob/a944e7744e57a5a2c13f3c73b9735edf2f71e329/src/lightning/fabric/plugins/environments/slurm.py
-        return "SLURM_NTASKS" in os.environ and not (os.environ.get("SLURM_JOB_NAME") in ("bash", "interactive"))
+        return "SLURM_NTASKS" in os.environ and os.environ.get("SLURM_JOB_NAME") not in ("bash", "interactive")
 
     def __spawn_parallel_procs(self, num_procs):
         """When srun is not available, this method creates N-1 child processes within the same node for parallel inference"""
@@ -166,8 +166,9 @@ class ParallelRunner(DefaultRunner):
 
             # since we are running within a node, 'localhost' and any port can be used
             self.master_addr = "localhost"
-            #generates a port between 10000 and 19999, based on the nodes hostname (which will be the same across all node-local procs)
+            # generates a port between 10000 and 19999, based on the nodes hostname (which will be the same across all node-local procs)
             import hashlib
+
             node_name = os.uname().nodename.encode()  # Convert to bytes
             hash_val = int(hashlib.md5(node_name).hexdigest(), 16)  # Convert hash to int
             self.master_port = 10000 + (hash_val % 9999)

--- a/src/anemoi/inference/runners/parallel.py
+++ b/src/anemoi/inference/runners/parallel.py
@@ -163,6 +163,10 @@ class ParallelRunner(DefaultRunner):
             self.global_rank = self.config.pid  # only inference within a single node is supported when not using srun
             self.local_rank = self.config.pid
             self.world_size = self.config.world_size
+            if self.world_size == 1:
+                LOG.warning("You selected 'runner: parallel' but you have only set 'world_size: 1'. Please update world_size or launch via srun to make use of parallel inference")
+            if self.world_size <= 0:
+                raise ValueError(f"Error. 'world_size' must be greater then 1 to use parallel inference. {world_size=} set in the config is invalid.")
 
             # since we are running within a node, 'localhost' and any port can be used
             self.master_addr = "localhost"

--- a/src/anemoi/inference/runners/parallel.py
+++ b/src/anemoi/inference/runners/parallel.py
@@ -164,9 +164,13 @@ class ParallelRunner(DefaultRunner):
             self.local_rank = self.config.pid
             self.world_size = self.config.world_size
             if self.world_size == 1:
-                LOG.warning("You selected 'runner: parallel' but you have only set 'world_size: 1'. Please update world_size or launch via srun to make use of parallel inference")
+                LOG.warning(
+                    "You selected 'runner: parallel' but you have only set 'world_size: 1'. Please update world_size or launch via srun to make use of parallel inference"
+                )
             if self.world_size <= 0:
-                raise ValueError(f"Error. 'world_size' must be greater then 1 to use parallel inference. {world_size=} set in the config is invalid.")
+                raise ValueError(
+                    f"Error. 'world_size' must be greater then 1 to use parallel inference. {world_size=} set in the config is invalid."
+                )
 
             # since we are running within a node, 'localhost' and any port can be used
             self.master_addr = "localhost"


### PR DESCRIPTION
This PR extends the Parallel Inference added in #55 to work without slurm **within 1 node**. It's much nicer to debug and run now :D

When running parallel inference without slurm, you have to add `world_size` to the config. At the moment, this is ignored in favour of `SLURM_NTASKS` when running with srun. An example of a config running parallel inference across 4 nodes is shown below. You can launch this job as normal with `anemoi-inference run parinf.yaml`.

```yaml
checkpoint: /path/to/inference-last.ckpt
lead_time: 60
runner: parallel
world_size: 4 #Only required if running parallel inference without Slurm
input:
  grib: /path/to/input.grib
output:
  grib: /path/to/output.grib
```


How it works is:
- check if anemoi-inference is launched by srun
- if not, spawn `config.world_size` processes
   - `master_addr` is `localhost`
   - `master_port` is a hash of the node name, within a range. 
- Each spawned process runs a slimmed down version `RunCmd.run` but with the config preloaded


Issues:

- The master port calculation would lead to a clash if two parallel inference processes ran on the same node at the same time. 
- At the moment, I have a copy of `RunCmd.run` in `runners/parallel.py`. Would be nice to be able to use that code directly, rather then having to maintain a copy. To do this, I would just have to be able to pass a loaded config instead of a path

<!-- readthedocs-preview anemoi-inference start -->
----
📚 Documentation preview 📚: https://anemoi-inference--121.org.readthedocs.build/en/121/

<!-- readthedocs-preview anemoi-inference end -->