### PR TITLE
feat(config): Add `accumulate_from_start_of_forecast` post-processor

### DIFF
--- a/src/anemoi/inference/config.py
+++ b/src/anemoi/inference/config.py
@@ -14,6 +14,7 @@ import logging
 import os
 from typing import Any
 from typing import Dict
+from typing import List
 from typing import Literal
 from typing import Optional
 from typing import Union
@@ -58,6 +59,9 @@ class Configuration(BaseModel):
 
     input: Union[str, Dict, None] = "test"
     output: Union[str, Dict, None] = "printer"
+
+    pre_processors: List[Union[str, Dict]] = []
+    post_processors: Optional[List[Union[str, Dict]]] = None  # TODO: change default to [] when we have a factory
 
     forcings: Union[Dict[str, Dict], None] = None
     """Where to find the forcings."""

--- a/src/anemoi/inference/runner.py
+++ b/src/anemoi/inference/runner.py
@@ -54,7 +54,7 @@ class Runner(Context):
         self,
         checkpoint,
         *,
-        accumulations=True,
+        accumulations=False,
         device: str = "cuda",
         precision: str = None,
         report_error=False,

--- a/src/anemoi/inference/runners/default.py
+++ b/src/anemoi/inference/runners/default.py
@@ -9,6 +9,7 @@
 
 
 import logging
+import warnings
 
 from anemoi.utils.config import DotDict
 from pydantic import BaseModel
@@ -40,6 +41,37 @@ class DefaultRunner(Runner):
 
         self.config = config
 
+        # TODO #131: Remove this when we have a processor factory
+        # For now, implement a three-way switch.
+        # post_processors: None -> accumulate_from_start_of_forecast = True
+        # post_processors: []   -> accumulate_from_start_of_forecast = False
+        # post_processors: ["accumulate_from_start_of_forecast"] -> accumulate_from_start_of_forecast = True
+        post_processors = config.get("post_processors")
+
+        if isinstance(post_processors, list):
+            accumulate_from_start_of_forecast = "accumulate_from_start_of_forecast" in post_processors
+
+            if not accumulate_from_start_of_forecast:
+                warnings.warn(
+                    """
+                    post_processors are defined but `accumulate_from_start_of_forecast` is not set."
+                    🚧 Accumulations will NOT be accumulated from the beginning of the forecast. 🚧
+                    """
+                )
+        else:
+            warnings.warn(
+                """
+                No post_processors defined. Accumulations will be accumulated from the beginning of the forecast.
+
+                🚧🚧🚧 In a future release, the default will be to NOT accumulate from the beginning of the forecast. 🚧🚧🚧
+                Update your config if you wish to keep accumulating from the beginning.
+                https://github.com/ecmwf/anemoi-inference/issues/131
+                """,
+            )
+            accumulate_from_start_of_forecast = True
+
+        LOG.info("accumulate_from_start_of_forecast: %s", accumulate_from_start_of_forecast)
+
         super().__init__(
             config.checkpoint,
             device=config.device,
@@ -52,6 +84,7 @@ class DefaultRunner(Runner):
             development_hacks=config.development_hacks,
             output_frequency=config.output_frequency,
             write_initial_state=config.write_initial_state,
+            accumulations=accumulate_from_start_of_forecast,
         )
 
     def create_input(self):


### PR DESCRIPTION
Implements step 1 and 2 of #131 

For CLI and OO API users: if `post_processors` is not defined in the user-config, the current behaviour is to keep accumulating from the beginning of the forecast. A warning is shown to alert users that this will change in the future.

To explicitly turn accumulations from beginning of the forecast on or off, the user can do:

```yaml
# on
post_processors: 
  - accumulate_from_start_of_forecast
```
```yaml
# off
post_processors: []
```

For the numpy-to-numpy API  it is turned off by default.

