### PR TITLE
feat: get specific values and keys from metadata

### DIFF
--- a/src/anemoi/inference/commands/metadata.py
+++ b/src/anemoi/inference/commands/metadata.py
@@ -78,6 +78,11 @@ class Metadata(Command):
             help="Print the supporting arrays.",
         )
 
+        group.add_argument(
+            "--get",
+            help="Navigate the metadata via dot-separated path.",
+        )
+
         command_parser.add_argument(
             "--name",
             default=DEFAULT_NAME,
@@ -124,6 +129,9 @@ class Metadata(Command):
 
         if args.view:
             return self.view(args)
+
+        if args.get:
+            return self.get(args)
 
         if args.remove:
             return self.remove(args)
@@ -200,6 +208,31 @@ class Metadata(Command):
         if args.json or True:
             print(json.dumps(metadata, indent=4, sort_keys=True), file=file)
             return
+
+    def get(self, args):
+        from pprint import pprint
+
+        from anemoi.utils.checkpoints import load_metadata
+
+        metadata = load_metadata(args.path, name=args.name)
+
+        if args.get == ".":
+            print("Metadata from root: ", list(metadata.keys()))
+            return
+
+        for key in args.get.split("."):
+            if key == "":
+                keys = list(metadata.keys())
+                print(f"Metadata keys from {args.get[:-1]}: ", keys)
+                return
+            else:
+                metadata = metadata[key]
+
+        print(f"Metadata values for {args.get}: ", end="\n" if isinstance(metadata, (dict, list)) else "")
+        if isinstance(metadata, dict):
+            pprint(metadata, indent=2, compact=True)
+        else:
+            print(metadata)
 
     def load(self, args):
         from anemoi.utils.checkpoints import has_metadata


### PR DESCRIPTION
## Description

Adds the option to print out a specific part of the metadata from a checkpoint, using dot notation. For instance:

- `anemoi-inference metadata <checkpoint> --get config.dataloader` prints out the dataloader config
- `anemoi-inference metadata <checkpoint> --get provenance_training.` (note the dot at the end) prints out the keys at that node in the dictionary tree
- `anemoi-inference metadata <checkpoint> --get provenance_training.module_versions` prints out the versions of all training dependencies
- `anemoi-inference metadata <checkpoint> --get .` prints out the top-level keys


## Type of Change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I ran the [complete Pytest test](https://anemoi.readthedocs.io/projects/training/en/latest/dev/testing.html) suite locally, and they pass

### Dependencies

-   [x] I have ensured that the code is still pip-installable after the changes and runs
-   [x] I have tested that new dependencies themselves are pip-installable.

<!-- List any new dependencies that are required for this change and the justification to add them. -->

### Documentation

-   [ ] My code follows the style guidelines of this project
-   [ ] I have updated the documentation and docstrings to reflect the changes
-   [ ] I have added comments to my code, particularly in hard-to-understand areas

<!-- Describe any major updates to the documentation -->

## Additional Notes

<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->
