### PR TITLE
fix: Post processors

### DIFF
--- a/src/anemoi/inference/runner.py
+++ b/src/anemoi/inference/runner.py
@@ -54,7 +54,6 @@ class Runner(Context):
         self,
         checkpoint,
         *,
-        accumulate_from_start_of_forecast=False,
         device: str = "cuda",
         precision: str = None,
         report_error=False,

--- a/src/anemoi/inference/runner.py
+++ b/src/anemoi/inference/runner.py
@@ -121,8 +121,6 @@ class Runner(Context):
         input_state = input_state.copy()
         input_state["fields"] = input_state["fields"].copy()
 
-        input_state = self.preprocess(input_state)
-
         self.constant_forcings_inputs = self.checkpoint.constant_forcings_inputs(self, input_state)
         self.dynamic_forcings_inputs = self.checkpoint.dynamic_forcings_inputs(self, input_state)
         self.boundary_forcings_inputs = self.checkpoint.boundary_forcings_inputs(self, input_state)

--- a/src/anemoi/inference/runners/default.py
+++ b/src/anemoi/inference/runners/default.py
@@ -43,9 +43,6 @@ class DefaultRunner(Runner):
 
         self.config = config
 
-        # temporary code
-        accumulate_from_start_of_forecast = _check_accumulation_processor(config)
-
         super().__init__(
             config.checkpoint,
             device=config.device,
@@ -59,7 +56,6 @@ class DefaultRunner(Runner):
             output_frequency=config.output_frequency,
             write_initial_state=config.write_initial_state,
             trace_path=config.trace_path,
-            accumulate_from_start_of_forecast=accumulate_from_start_of_forecast,
             use_profiler=config.use_profiler,
         )
 
@@ -157,44 +153,3 @@ class DefaultRunner(Runner):
 
         LOG.info("Post processors: %s", result)
         return result
-
-
-def _check_accumulation_processor(config):
-    # TODO #131: Remove this when we have a processor factory
-    # For now, implement a three-way switch.
-    # post_processors: None -> accumulate_from_start_of_forecast = True
-    # post_processors: []   -> accumulate_from_start_of_forecast = False
-    # post_processors: ["accumulate_from_start_of_forecast"] -> accumulate_from_start_of_forecast = True
-    pre_processors = config.get("pre_processors")
-    post_processors = config.get("post_processors")
-
-    if pre_processors:
-        raise NotImplementedError("pre_processors are not yet supported. Please remove this entry from your config.")
-
-    if post_processors not in (None, [], ["accumulate_from_start_of_forecast"]):
-        raise ValueError("post_processors only supports `accumulate_from_start_of_forecast`.")
-
-    if isinstance(post_processors, list):
-        accumulate_from_start_of_forecast = "accumulate_from_start_of_forecast" in post_processors
-
-        if not accumulate_from_start_of_forecast:
-            warnings.warn(
-                """
-                post_processors are defined but `accumulate_from_start_of_forecast` is not set."
-                🚧 Accumulations will NOT be accumulated from the beginning of the forecast. 🚧
-                """
-            )
-    else:
-        warnings.warn(
-            """
-            No post_processors defined. Accumulations will be accumulated from the beginning of the forecast.
-
-            🚧🚧🚧 In a future release, the default will be to NOT accumulate from the beginning of the forecast. 🚧🚧🚧
-            Update your config if you wish to keep accumulating from the beginning.
-            https://github.com/ecmwf/anemoi-inference/issues/131
-            """,
-        )
-        accumulate_from_start_of_forecast = True
-
-    LOG.info("accumulate_from_start_of_forecast: %s", accumulate_from_start_of_forecast)
-    return accumulate_from_start_of_forecast

--- a/src/anemoi/inference/runners/default.py
+++ b/src/anemoi/inference/runners/default.py
@@ -127,8 +127,8 @@ class DefaultRunner(Runner):
         # post_processors: []   -> accumulate_from_start_of_forecast = False
         # post_processors: ["accumulate_from_start_of_forecast"] -> accumulate_from_start_of_forecast = True
 
-        if self.config.pre_processors is None:
-            self.config.pre_processors = ["accumulate_from_start_of_forecast"]
+        if self.config.post_processors is None:
+            self.config.post_processors = ["accumulate_from_start_of_forecast"]
             warnings.warn(
                 """
                 No post_processors defined. Accumulations will be accumulated from the beginning of the forecast.
@@ -137,6 +137,14 @@ class DefaultRunner(Runner):
                 Update your config if you wish to keep accumulating from the beginning.
                 https://github.com/ecmwf/anemoi-inference/issues/131
                 """,
+            )
+
+        if "accumulate_from_start_of_forecast" not in self.config.post_processors:
+            warnings.warn(
+                """
+                post_processors are defined but `accumulate_from_start_of_forecast` is not set."
+                🚧 Accumulations will NOT be accumulated from the beginning of the forecast. 🚧
+                """
             )
 
         result = []


### PR DESCRIPTION
## Description

- Fixes a crash that happens when post_processors is not defined in the config. 
- Remove leftover temporary code from before we had a processor factory.

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

Related to #131 , the logic that facilitates the transition to not accumulating by default was broken. 

## Code Compatibility

-   [x] I have performed a self-review of my code