### PR TITLE
fix: Remove `hdate` from variable keys

### DIFF
--- a/src/anemoi/inference/grib/encoding.py
+++ b/src/anemoi/inference/grib/encoding.py
@@ -124,7 +124,6 @@ def grib_keys(
     previous_step,
     start_steps,
     keys,
-    quiet,
     grib1_keys={},
     grib2_keys={},
 ):

--- a/src/anemoi/inference/grib/encoding.py
+++ b/src/anemoi/inference/grib/encoding.py
@@ -178,7 +178,7 @@ def grib_keys(
     )
 
     for k, v in variable.grib_keys.items():
-        if k not in ("domain", "type", "stream", "expver", "class", "param", "number", "step", "date", "time"):
+        if k not in ("domain", "type", "stream", "expver", "class", "param", "number", "step", "date", "hdate", "time"):
             if k == "levtype":
                 v = LEVTYPES.get(v)
                 if v is None:

--- a/src/anemoi/inference/metadata.py
+++ b/src/anemoi/inference/metadata.py
@@ -421,7 +421,7 @@ class Metadata(PatchMixin, LegacyMixin):
 
             mars = self.variables_metadata[variable]["mars"].copy()
 
-            for k in ("date", "time"):
+            for k in ("date", "hdate", "time"):
                 mars.pop(k, None)
 
             yield mars

--- a/src/anemoi/inference/outputs/grib.py
+++ b/src/anemoi/inference/outputs/grib.py
@@ -87,7 +87,6 @@ class GribOutput(Output):
         super().__init__(context, output_frequency=output_frequency, write_initial_state=write_initial_state)
         self._first = True
         self.typed_variables = self.checkpoint.typed_variables
-        self.quiet = set()
         self.encoding = encoding if encoding is not None else {}
         self.grib1_keys = grib1_keys if grib1_keys is not None else {}
         self.grib2_keys = grib2_keys if grib2_keys is not None else {}
@@ -164,18 +163,6 @@ class GribOutput(Output):
 
             template = self.template(state, name)
 
-            if template is None:
-                if name not in self.quiet:
-                    LOG.warning("No GRIB template found for `%s`. This may lead to unexpected results.", name)
-                    self.quiet.add(name)
-
-                variable_keys = variable.grib_keys.copy()
-                forbidden_keys = ("class", "type", "stream", "expver", "date", "time", "step", "domain")
-                for key in forbidden_keys:
-                    variable_keys.pop(key, None)
-
-                keys.update(variable_keys)
-
             keys.update(self.encoding)
 
             keys = grib_keys(
@@ -190,7 +177,6 @@ class GribOutput(Output):
                 keys=keys,
                 grib1_keys=self.grib1_keys,
                 grib2_keys=self.grib2_keys,
-                quiet=self.quiet,
                 previous_step=previous_step,
                 start_steps=start_steps,
             )


### PR DESCRIPTION
## Description

The checkpoint variables metadata might contain an `hdate` key in the data request, if the model was trained on hindcast data.

This key needs to be skipped when constructing the initial condition request and writing to grib. 

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
