### PR TITLE
fix: param id handling at archive JSON output

### DIFF
--- a/src/anemoi/inference/outputs/gribfile.py
+++ b/src/anemoi/inference/outputs/gribfile.py
@@ -199,13 +199,17 @@ class GribFileOutput(GribOutput):
 
         def _patch(r):
             if self.context.config.use_grib_paramid:
-                from anemoi.utils.grib import shortname_to_paramid
-
                 param = r.get("param", [])
                 if not isinstance(param, list):
                     param = [param]
-                param = [shortname_to_paramid(p) for p in param]
-                r["param"] = param
+
+                # Check if we're using param ids already
+                try:
+                    float(next(iter(param)))
+                except ValueError:
+                    from anemoi.utils.grib import shortname_to_paramid
+
+                    r["param"] = [shortname_to_paramid(p) for p in param]
 
             for k, v in patch.items():
                 if v is None:


### PR DESCRIPTION
## Description

When requesting output of parameter ids instead of short codes we got an error if we already had param ids in the request. This adds a check to see what we have an skips the lookup step.

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

