### PR TITLE
fix(grib): Remove duplicate grib key logic

### DIFF
--- a/src/anemoi/inference/outputs/grib.py
+++ b/src/anemoi/inference/outputs/grib.py
@@ -156,7 +156,6 @@ class GribOutput(Output):
         super().__init__(context, output_frequency=output_frequency, write_initial_state=write_initial_state)
         self._first = True
         self.typed_variables = self.checkpoint.typed_variables
-        self.quiet = set()
         self.encoding = encoding if encoding is not None else {}
         self.grib1_keys = grib1_keys if grib1_keys is not None else {}
         self.grib2_keys = grib2_keys if grib2_keys is not None else {}
@@ -247,20 +246,6 @@ class GribOutput(Output):
 
             template = self.template(state, name)
 
-            if template is None:
-                if name not in self.quiet:
-                    LOG.warning("No GRIB template found for `%s`. This may lead to unexpected results.", name)
-                    self.quiet.add(name)
-
-                variable_keys = variable.grib_keys.copy()
-
-                forbidden_keys = ("class", "type", "stream", "expver", "date", "time", "step", "domain")
-
-                for key in forbidden_keys:
-                    variable_keys.pop(key, None)
-
-                keys.update(variable_keys)
-
             keys.update(self.encoding)
 
             keys = grib_keys(
@@ -275,7 +260,6 @@ class GribOutput(Output):
                 keys=keys,
                 grib1_keys=self.grib1_keys,
                 grib2_keys=self.grib2_keys,
-                quiet=self.quiet,
                 previous_step=previous_step,
                 start_steps=start_steps,
             )


### PR DESCRIPTION
The list of "forbidden keys" that should be skipped when building the output keys now lives in [grib_keys()](https://github.com/ecmwf/anemoi-inference/blob/9313155e7bc19b0fce51f6330c98761343ccfb54/src/anemoi/inference/grib/encoding.py#L281). 

So it can be removed here.