### PR TITLE
fix: Add check for date is None with earthkit-data GRIB input

### DIFF
--- a/src/anemoi/inference/inputs/ekd.py
+++ b/src/anemoi/inference/inputs/ekd.py
@@ -413,7 +413,14 @@ class EkdInput(Input):
         State
             The created input state.
         """
+        if date is None:
+            date = input_fields.order_by(valid_datetime="ascending")[-1].datetime()["valid_time"]
+            LOG.info(
+                "%s: `date` not provided, using the most recent date: %s", self.__class__.__name__, date.isoformat()
+            )
+
         dates = [date + h for h in self.checkpoint.lagged]
+
         return self._create_state(
             input_fields,
             variables=variables,

--- a/src/anemoi/inference/inputs/ekd.py
+++ b/src/anemoi/inference/inputs/ekd.py
@@ -382,7 +382,7 @@ class EkdInput(Input):
         self,
         input_fields: ekd.FieldList,
         *,
-        date: Date,
+        date: Optional[Date] = None,
         variables: Optional[List[str]] = None,
         latitudes: Optional[FloatArray] = None,
         longitudes: Optional[FloatArray] = None,


### PR DESCRIPTION
## Description

Adds a check if the date is None with the earthkit-data GRIB input.

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

