### PR TITLE
fix(netcdf): Fix context time attributes

### DIFF
--- a/src/anemoi/inference/outputs/netcdf.py
+++ b/src/anemoi/inference/outputs/netcdf.py
@@ -91,10 +91,12 @@ class NetCDFOutput(Output):
 
         time = 0
         self.reference_date = state["date"]
-        if hasattr(self.context, "time_step") and hasattr(self.context, "lead_time"):
-            time = self.context.lead_time // self.context.time_step
-        if hasattr(self.context, "reference_date"):
-            self.reference_date = self.context.reference_date
+        if (time_step := getattr(self.context, "time_step", None)) and (
+            lead_time := getattr(self.context, "lead_time", None)
+        ):
+            time = lead_time // time_step
+        if reference_date := getattr(self.context, "reference_date", None):
+            self.reference_date = reference_date
 
         with LOCK:
             self.values_dim = self.ncfile.createDimension("values", values)

--- a/src/anemoi/inference/runner.py
+++ b/src/anemoi/inference/runner.py
@@ -214,10 +214,6 @@ class Runner(Context):
 
         lead_time = to_timedelta(lead_time)
 
-        # This may be used but Output objects to compute the step
-        self.lead_time = lead_time
-        self.time_step = self.checkpoint.timestep
-
         with ProfilingRunner(self.use_profiler):
             with ProfilingLabel("Prepare input tensor", self.use_profiler):
                 input_tensor = self.prepare_input_tensor(input_state)

--- a/src/anemoi/inference/runners/default.py
+++ b/src/anemoi/inference/runners/default.py
@@ -15,6 +15,7 @@ from typing import Dict
 from typing import List
 
 from anemoi.utils.config import DotDict
+from anemoi.utils.dates import frequency_to_timedelta as to_timedelta
 from pydantic import BaseModel
 
 from anemoi.inference.config import Configuration
@@ -86,6 +87,12 @@ class DefaultRunner(Runner):
         if self.config.description is not None:
             LOG.info("%s", self.config.description)
 
+        lead_time = to_timedelta(self.config.lead_time)
+
+        # This may be used by Output objects to compute the step
+        self.lead_time = lead_time
+        self.time_step = self.checkpoint.timestep
+
         input = self.create_input()
         output = self.create_output()
 
@@ -104,7 +111,7 @@ class DefaultRunner(Runner):
         output.open(state)
         output.write_initial_state(state)
 
-        for state in self.run(input_state=input_state, lead_time=self.config.lead_time):
+        for state in self.run(input_state=input_state, lead_time=lead_time):
             for processor in post_processors:
                 LOG.info("Post processor: %s", processor)
                 state = processor.process(state)


### PR DESCRIPTION
## Description

Two bugs:

1. The netcdf output uses the context attributes `self.lead_time` and `self.time_step` in the `open` routine, which is called before these attributes are set.
2. `NetCDFOutput.open` reads reference_date from the context, but doesn't check if the value is not None. 

- Set the context attributes `self.lead_time` and `self.time_step` at the beginning of execute, before they are accessed.
- Check if the context reference_date is not None, otherwise use the date from the state.

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
