### PR TITLE
fix: Improve Testing Decorators

### DIFF
--- a/src/anemoi/inference/testing/__init__.py
+++ b/src/anemoi/inference/testing/__init__.py
@@ -9,6 +9,7 @@
 
 
 import datetime
+import functools
 import os
 from typing import Any
 from typing import Callable
@@ -28,6 +29,7 @@ def fake_checkpoints(func: Callable[..., Any]) -> Callable[..., Any]:
         The decorated function.
     """
 
+    @functools.wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
         from unittest.mock import patch
 


### PR DESCRIPTION
Add `functools.wraps` to decorator to allow usage of `pytest.marks` in downstream tests.

## Example
```python
@pytest.mark.parametrize(
    "arg1, arg2",
    [
        ("wow", 'test'),
    ],
)
@fake_checkpoints
def test(arg1, arg2):
	assert arg1 != arg2
```