### PR TITLE
fix: Allow for downstream tests to provide checkpoint mocks

### DIFF
--- a/src/anemoi/inference/testing/__init__.py
+++ b/src/anemoi/inference/testing/__init__.py
@@ -31,6 +31,7 @@ def fake_checkpoints(func: Callable[..., Any]) -> Callable[..., Any]:
 
     @functools.wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
+        from unittest.mock import MagicMock
         from unittest.mock import patch
 
         from .mock_checkpoint import MockRunConfiguration
@@ -39,6 +40,7 @@ def fake_checkpoints(func: Callable[..., Any]) -> Callable[..., Any]:
 
         with (
             patch("anemoi.inference.checkpoint.load_metadata", mock_load_metadata),
+            patch("anemoi.inference.provenance.validate_environment", MagicMock()),
             patch("torch.load", mock_torch_load),
             patch("anemoi.inference.metadata.USE_LEGACY", True),
             patch("anemoi.inference.tasks.runner.RunConfiguration", MockRunConfiguration),

--- a/src/anemoi/inference/testing/mock_checkpoint.py
+++ b/src/anemoi/inference/testing/mock_checkpoint.py
@@ -82,7 +82,8 @@ def mock_load_metadata(path: Optional[str], *, supporting_arrays: bool = True) -
     if path is None:
         metadata = SIMPLE_METADATA
     else:
-        path = files_for_tests(os.path.join("checkpoints", path))
+        if not os.path.isabs(path):
+            path = files_for_tests(os.path.join("checkpoints", path))
         name, _ = os.path.splitext(path)
         for ext in (".yaml", ".json"):
             path = f"{name}{ext}"


### PR DESCRIPTION
Mocking checkpoints didn't allow for downstream tests to mock metadata