### PR TITLE
fix: Inference with crps requires additional arguments in predict_step

### DIFF
--- a/src/anemoi/inference/runner.py
+++ b/src/anemoi/inference/runner.py
@@ -476,7 +476,7 @@ class Runner(Context):
         torch.Tensor
             The predicted step.
         """
-        return model.predict_step(input_tensor_torch)
+        return model.predict_step(input_tensor_torch, **kwargs)
 
     def forecast_stepper(
         self, start_date: datetime.datetime, lead_time: datetime.timedelta

--- a/src/anemoi/inference/runner.py
+++ b/src/anemoi/inference/runner.py
@@ -476,7 +476,7 @@ class Runner(Context):
         torch.Tensor
             The predicted step.
         """
-        return model.predict_step(input_tensor_torch, **kwargs)
+        return model.predict_step(input_tensor_torch)
 
     def forecast_stepper(
         self, start_date: datetime.datetime, lead_time: datetime.timedelta

--- a/src/anemoi/inference/runner.py
+++ b/src/anemoi/inference/runner.py
@@ -476,7 +476,12 @@ class Runner(Context):
         torch.Tensor
             The predicted step.
         """
-        return model.predict_step(input_tensor_torch, **kwargs)
+        try:
+            return model.predict_step(input_tensor_torch, **kwargs)
+        except TypeError:
+            # This is for backward compatibility because old models did not
+            # have kwargs in the forward or predict_step
+            return model.predict_step(input_tensor_torch)
 
     def forecast_stepper(
         self, start_date: datetime.datetime, lead_time: datetime.timedelta

--- a/src/anemoi/inference/runners/crps.py
+++ b/src/anemoi/inference/runners/crps.py
@@ -40,4 +40,4 @@ class CrpsRunner(DefaultRunner):
         Any
             The prediction result.
         """
-        return model.predict_step(input_tensor_torch, kwargs["fcstep"])
+        return model.predict_step(input_tensor_torch, fcstep=kwargs["fcstep"])

--- a/src/anemoi/inference/runners/crps.py
+++ b/src/anemoi/inference/runners/crps.py
@@ -8,6 +8,7 @@
 # nor does it submit to any jurisdiction.
 
 import logging
+import warnings
 from typing import Any
 
 from . import runner_registry
@@ -40,4 +41,5 @@ class CrpsRunner(DefaultRunner):
         Any
             The prediction result.
         """
-        return model.predict_step(input_tensor_torch, fcstep=kwargs["fcstep"])
+        warnings.warn("CRPS runner is deprecated, use DefaultRunner instead")
+        return model.predict_step(input_tensor_torch, kwargs["fcstep"])


### PR DESCRIPTION
## Description

The problem is described in https://github.com/ecmwf/anemoi-core/pull/277. The forward function of `AnemoiEnsModelEncProcDec` takes additional arguments that need to be passed from anemoi-inference.