### PR TITLE
fix: extract-lam

### DIFF
--- a/src/anemoi/inference/outputs/extract_lam.py
+++ b/src/anemoi/inference/outputs/extract_lam.py
@@ -63,7 +63,7 @@ class ExtractLamOutput(ForwardOutput):
             if "lam_1/cutout_mask" in self.checkpoint.supporting_arrays:
                 raise NotImplementedError("Only lam_0 is supported")
 
-            mask = self.checkpoint.load_supporting_array(f"{lam}/cutout_mask")
+            mask = self.checkpoint.load_supporting_array(f"0/{lam}/cutout_mask")
             assert len(mask) == np.sum(mask)
             points = slice(None, np.sum(mask))
 


### PR DESCRIPTION
## Description

Extract lam output reduces the output to that of the lam region, which is defined by the `cutout_mask` as stored in the checkpoint. The correct supporting array is `0/lam_0/cutout_mask`, in the code it was erroneously referenced as  `lam_0/cutout_mask`. This typo is fixed.

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

Closes #86 

<!-- Alternatively, explain the motivation behind the changes and the context in which they are being made. -->

## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [x] I have added tests that prove my fix is effective or that my feature works
-   [ ] I ran the [complete Pytest test](https://anemoi.readthedocs.io/projects/training/en/latest/dev/testing.html) suite locally, and they pass

<!-- In case this affects the model sharding or other specific components please describe these here. -->

### Dependencies

-   [x] I have ensured that the code is still pip-installable after the changes and runs
-   [ ] I have tested that new dependencies themselves are pip-installable.

<!-- List any new dependencies that are required for this change and the justification to add them. -->

### Documentation

-   [ ] My code follows the style guidelines of this project
-   [ ] I have updated the documentation and docstrings to reflect the changes
-   [ ] I have added comments to my code, particularly in hard-to-understand areas

<!-- Describe any major updates to the documentation -->

## Additional Notes

<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->
