### PR TITLE
fix!: do not set 'eps' key in grib encoding

### DIFF
--- a/src/anemoi/inference/grib/encoding.py
+++ b/src/anemoi/inference/grib/encoding.py
@@ -246,8 +246,6 @@ def grib_keys(
 
     result["edition"] = edition
 
-    result["eps"] = 1 if ensemble else 0
-
     if param is not None:
         result.setdefault(_param(param), param)
 


### PR DESCRIPTION
## Description

During the encoding of the `grib` output, `eccodes` raises the following error:

```
KeyValueNotFoundError: Key/value not found
```

this happens when trying to set the `eps` key. It appears that this key not universally compatible with GRIB encodings. Therefore, this PR removes the hardcoded specification. 

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
