### PR TITLE
fix: boundary forcings inputs

### DIFF
--- a/src/anemoi/inference/metadata.py
+++ b/src/anemoi/inference/metadata.py
@@ -959,16 +959,13 @@ class Metadata(PatchMixin, LegacyMixin):
         list
             The list of boundary forcings inputs.
         """
-        result = []
-
-        if "output_mask" in self._supporting_arrays:
-            result.append(
-                context.create_boundary_forcings(
+        if "output_mask" not in self._supporting_arrays:
+            return []
+            
+        return context.create_boundary_forcings(
                     self.prognostic_variables,
                     self.prognostic_input_mask,
                 )
-            )
-        return result
 
     ###########################################################################
     # Supporting arrays

--- a/src/anemoi/inference/metadata.py
+++ b/src/anemoi/inference/metadata.py
@@ -961,11 +961,11 @@ class Metadata(PatchMixin, LegacyMixin):
         """
         if "output_mask" not in self._supporting_arrays:
             return []
-            
+
         return context.create_boundary_forcings(
-                    self.prognostic_variables,
-                    self.prognostic_input_mask,
-                )
+            self.prognostic_variables,
+            self.prognostic_input_mask,
+        )
 
     ###########################################################################
     # Supporting arrays


### PR DESCRIPTION
## Description

After forcings were refactored `boundary_forcings_inputs` was returning a list of lists, rather than a list, in the non trivial case where the checkpoint contains the `output_mask` supporting array. This PR fixes this.

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

<!-- Link the Issue number this change addresses, ideally in one of the "magic format" such as Closes #XYZ -->

<!-- Alternatively, explain the motivation behind the changes and the context in which they are being made. -->

## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I ran the [complete Pytest test](https://anemoi.readthedocs.io/projects/training/en/latest/dev/testing.html) suite locally, and they pass

<!-- In case this affects the model sharding or other specific components please describe these here. -->

### Dependencies

-   [x] I have ensured that the code is still pip-installable after the changes and runs
-   [ ] I have tested that new dependencies themselves are pip-installable.

<!-- List any new dependencies that are required for this change and the justification to add them. -->

### Documentation

-   [ ] My code follows the style guidelines of this project
-   [ ] I have updated the documentation and docstrings to reflect the changes
-   [ ] I have added comments to my code, particularly in hard-to-understand areas

<!-- Describe any major updates to the documentation -->

## Additional Notes

<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->
