### PR TITLE
feat: Add cmd options to editor

### DIFF
--- a/src/anemoi/inference/commands/metadata.py
+++ b/src/anemoi/inference/commands/metadata.py
@@ -24,6 +24,8 @@ from . import Command
 
 LOG = logging.getLogger(__name__)
 
+EDITOR_OPTIONS = {"code": ["--wait"]}
+
 
 class Metadata(Command):
     """Edit, remove, dump or load metadata from a checkpoint file."""
@@ -228,7 +230,7 @@ class Metadata(Command):
             with open(path, "w") as f:
                 dump(metadata, f, **kwargs)
 
-            subprocess.check_call([cmd, path])
+            subprocess.check_call([cmd, *EDITOR_OPTIONS.get(cmd, []), path])
 
             if not view:
                 with open(path) as f:


### PR DESCRIPTION
## Description

- Add code --wait

Allows for vscode to be used in the metadata command.

`anemoi-inference metadata --edit CHECKPOINT --editor code`


## Type of Change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update


## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [x] I ran the [complete Pytest test](https://anemoi.readthedocs.io/projects/training/en/latest/dev/testing.html) suite locally, and they pass

<!-- In case this affects the model sharding or other specific components please describe these here. -->

### Dependencies

-   [x] I have ensured that the code is still pip-installable after the changes and runs
-   [x] I have tested that new dependencies themselves are pip-installable.

<!-- List any new dependencies that are required for this change and the justification to add them. -->

### Documentation

-   [x] My code follows the style guidelines of this project
-   [x] I have updated the documentation and docstrings to reflect the changes
-   [x] I have added comments to my code, particularly in hard-to-understand areas

<!-- Describe any major updates to the documentation -->

