### PR TITLE
fix(metadata): Check for empty grid

### DIFF
--- a/src/anemoi/inference/legacy.py
+++ b/src/anemoi/inference/legacy.py
@@ -215,6 +215,6 @@ class LegacyMixin(MetadataProtocol):
                 if len(checks[c]) > 1:
                     warnings.warn(f"{c} is ambigous: {checks[c]}")
 
-            result = [r for r in result if r["grid"] is not None]
+            result = [r for r in result if r["grid"]]
 
         return result[0]


### PR DESCRIPTION
## Description

In some cases the grid stored in the metadata is an empty list `[]`.

When retrieving the grid from the metadata we only check if it is not None, but not if it is empty. So now change is so that it checks if the grid is truthy, to skip any falsy value like `None [] ""` etc

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
