### PR TITLE
fix: rename method on ForwardOutput class

### DIFF
--- a/src/anemoi/inference/output.py
+++ b/src/anemoi/inference/output.py
@@ -243,7 +243,7 @@ class ForwardOutput(Output):
 
         self.output.close()
 
-    def write_initial_step(self, state: State) -> None:
+    def write_initial_state(self, state: State) -> None:
         """Write the initial step of the state.
 
         Parameters


### PR DESCRIPTION
## Description

Rename the method `write_initial_step` of the `ForwardOutput` class to the correct name `write_initial_state`.
