### PR TITLE
fix(grib output): Respect `write_initial_state` option

### DIFF
--- a/src/anemoi/inference/outputs/grib.py
+++ b/src/anemoi/inference/outputs/grib.py
@@ -196,6 +196,9 @@ class GribOutput(Output):
         # We trust the GribInput class to provide the templates
         # matching the input state
 
+        if not self.write_step_zero:
+            return
+
         state = state.copy()
 
         self.reference_date = state["date"]
@@ -211,9 +214,9 @@ class GribOutput(Output):
 
             template = self.template(state, name)
             if template is None:
-                # We can currently only write grib output if we have a grib input
+                # grib output only reliably works when we have grib input, everything else relies on external templates
                 raise ValueError(
-                    "GRIB output only works if the input is GRIB (for now). Set `write_initial_step` to `false`."
+                    f"No grib template found for initial state param `{name}`. Try setting `write_initial_state` to `false`."
                 )
 
         return self.write_step(state)


### PR DESCRIPTION
## Description
Grib output was not respecting this option and always writing the initial state. This check exists in the base function, but was lost in the derived function.

## What issue or task does this change relate to?
closes #237

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***
