### PR TITLE
feat: Set debug log level on verbosity > 2

### DIFF
--- a/src/anemoi/inference/runner.py
+++ b/src/anemoi/inference/runner.py
@@ -154,6 +154,10 @@ class Runner(Context):
         self.post_processors = self.create_post_processors()
 
         if self.verbosity > 2:
+            logging.basicConfig(level=logging.DEBUG)
+            for logger_name in logging.root.manager.loggerDict:
+                logging.getLogger(logger_name).setLevel(logging.DEBUG)
+
             self.checkpoint.print_indices()
 
         LOG.info("Using %s runner, device=%s", self.__class__.__name__, self.device)


### PR DESCRIPTION
## Description
We have debug logging calls in a few places but we don't set the logger to debug level anywhere. This sets all loggers to debug level when verbosity > 2

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***
