### PR TITLE
fix: Improve external graph

### DIFF
--- a/docs/usage/external-graph.rst
+++ b/docs/usage/external-graph.rst
@@ -54,6 +54,14 @@ well:
 .. literalinclude:: yaml/external-graph3.yaml
    :language: yaml
 
+If you wish to run the external graph runner, but without the
+anemoi-dataset configuration, some supporting arrays may need to be
+updated. These can be sourced from either the ``graph['data']`` or from
+a file on disk. This is done with the ``update_supporting_arrays`` key
+
+.. literalinclude:: yaml/external-graph4.yaml
+   :language: yaml
+
 It should be emphasized that by using this runner the model will be
 rebuilt and for this reason will differ from the model stored in the
 checkpoint. To avoid unexpected results, there is a default check that
@@ -61,5 +69,5 @@ ensures the model used in inference has the same weights, biases and
 normalizer values as that stored in the checkpoint. In case of a more
 adventurous use-case this check can be disabled through the config as:
 
-.. literalinclude:: yaml/external-graph4.yaml
+.. literalinclude:: yaml/external-graph5.yaml
    :language: yaml

--- a/docs/usage/yaml/external-graph4.yaml
+++ b/docs/usage/yaml/external-graph4.yaml
@@ -1,4 +1,8 @@
 runner:
   external_graph:
     graph: path/to/graph.pt
-    check_state_dict: False
+    update_supporting_arrays:
+      graph: # Get data from the graph
+        'global/cutout_mask': 'cutout_mask'  # Change `global/cutout_mask` in the arrays to `cutout_mask`
+      file:
+        'global/cutout_mask': 'cutout_mask.npy'  # Change `global/cutout_mask` in the arrays to `cutout_mask.npy`

--- a/docs/usage/yaml/external-graph5.yaml
+++ b/docs/usage/yaml/external-graph5.yaml
@@ -1,0 +1,4 @@
+runner:
+  external_graph:
+    graph: path/to/graph.pt
+    check_state_dict: False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ dependencies = [
   "torch",
 ]
 
-optional-dependencies.all = [ "anemoi-inference[huggingface]", "anemoi-utils[all]>=0.4.16" ]
+optional-dependencies.all = [ "anemoi-datasets", "anemoi-inference[huggingface]", "anemoi-utils[all]>=0.4.16" ]
 
 optional-dependencies.dev = [ "anemoi-inference[all,docs,plugin,tests]" ]
 

--- a/src/anemoi/inference/runners/external_graph.py
+++ b/src/anemoi/inference/runners/external_graph.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2024 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
 import logging
 import os
 from copy import deepcopy
@@ -5,7 +14,6 @@ from functools import cached_property
 from typing import Any
 
 import torch
-from anemoi.datasets import open_dataset
 
 from ..runners.default import DefaultRunner
 from . import runner_registry
@@ -76,7 +84,7 @@ class ExternalGraphRunner(DefaultRunner):
         graph_dataset: Any | None = None,
         check_state_dict: bool | None = True,
     ) -> None:
-        """Initialize the ExternalGraphRunner.
+        """Initialise the ExternalGraphRunner.
 
         Parameters
         ----------
@@ -97,6 +105,8 @@ class ExternalGraphRunner(DefaultRunner):
 
         # If graph was build on other dataset, we need to adapt the dataloader
         if graph_dataset is not None:
+            from anemoi.datasets import open_dataset
+
             graph_ds = open_dataset(graph_dataset)
             LOG.info(
                 "The external graph was built using a different anemoi-dataset than that in the checkpoint. "

--- a/src/anemoi/inference/runners/external_graph.py
+++ b/src/anemoi/inference/runners/external_graph.py
@@ -16,6 +16,7 @@ from typing import Literal
 
 import torch
 
+from ..decorators import main_argument
 from ..runners.default import DefaultRunner
 from . import runner_registry
 
@@ -129,6 +130,7 @@ def get_updated_supporting_arrays(
 
 
 @runner_registry.register("external_graph")
+@main_argument("graph")
 class ExternalGraphRunner(DefaultRunner):
     """Runner where the graph saved in the checkpoint is replaced by an externally provided one.
     Currently only supported as an extension of the default runner.

--- a/src/anemoi/inference/runners/external_graph.py
+++ b/src/anemoi/inference/runners/external_graph.py
@@ -179,11 +179,8 @@ class ExternalGraphRunner(DefaultRunner):
                         key,
                     )
                 else:
-                    LOG.warning(
-                        "Key '%s' not found in external graph 'data'. Skipping update of supporting array '%s'.",
-                        value,
-                        key,
-                    )
+                    error_msg = f"Key '{value}' not found in external graph 'data'. Skipping update of supporting array '{key}'."
+                    raise KeyError(error_msg)
 
     @cached_property
     def graph(self):

--- a/src/anemoi/inference/runners/external_graph.py
+++ b/src/anemoi/inference/runners/external_graph.py
@@ -100,8 +100,8 @@ class ExternalGraphRunner(DefaultRunner):
             Argument to open_dataset of anemoi-datasets that recreates the dataset used to build the data nodes of the graph.
         update_supporting_arrays: dict[str, str] | None
             Dictionary specifying how to update the supporting arrays in the checkpoint metadata.
-            Will pull from the graph['data'] dictionary, key refers to the name in the graph,
-            and value refers to the name in the checkpoint metadata.
+            Will pull from the graph['data'] dictionary, key refers to the name in the supporting arrays,
+            and value refers to the name in the graph['data'].
         check_state_dict: bool | None
             Boolean specifying if reconstruction of statedict happens as expeceted.
         """
@@ -171,19 +171,18 @@ class ExternalGraphRunner(DefaultRunner):
 
         if update_supporting_arrays is not None:
             for key, value in update_supporting_arrays.items():
-                if key in self.graph["data"]:
-                    self.checkpoint._supporting_arrays[value] = self.graph["data"][key]
+                if value in self.graph["data"]:
+                    self.checkpoint._supporting_arrays[key] = self.graph["data"][value]
                     LOG.info(
-                        "Moving attribute '%s' of nodes '%s' from external graph to supporting arrays as '%s'.",
-                        key,
-                        "data",
+                        "Moving attribute '%s' from external graph to supporting arrays as '%s'.",
                         value,
+                        key,
                     )
                 else:
                     LOG.warning(
                         "Key '%s' not found in external graph 'data'. Skipping update of supporting array '%s'.",
-                        key,
                         value,
+                        key,
                     )
 
     @cached_property


### PR DESCRIPTION
## Description
Improvements being made to the external graph runner to allow the supporting arrays to be updated from the graph.
Additionally, removes anemoi-datasets as a hard dependancy.

## What problem does this change solve?
Enables broader usage of this runner.


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***


<!-- readthedocs-preview anemoi-inference start -->
----
📚 Documentation preview 📚: https://anemoi-inference--247.org.readthedocs.build/en/247/

<!-- readthedocs-preview anemoi-inference end -->