### PR TITLE
fix: apply mask to all sources in cutout input.

### DIFF
--- a/src/anemoi/inference/inputs/cutout.py
+++ b/src/anemoi/inference/inputs/cutout.py
@@ -9,15 +9,13 @@
 
 
 import logging
-from typing import List
-from typing import Optional
+from typing import Any, List, Optional
 
 import numpy as np
 
 from anemoi.inference.input import Input
 from anemoi.inference.inputs import create_input
-from anemoi.inference.types import Date
-from anemoi.inference.types import State
+from anemoi.inference.types import Date, State
 
 from . import input_registry
 
@@ -67,15 +65,24 @@ class Cutout(Input):
         LOG.info(f"Concatenating states from {self.sources}")
         sources = list(self.sources.keys())
 
-        state = self.sources[sources[0]].create_input_state(date=date)
-        for source in sources[1:]:
-            mask = self.masks[source]
-            _state = self.sources[source].create_input_state(date=date)
+        states: List[State] = [self.sources[source].create_input_state(date=date) for source in sources]
 
-            state["latitudes"] = np.concatenate([state["latitudes"], _state["latitudes"][..., mask]], axis=-1)
-            state["longitudes"] = np.concatenate([state["longitudes"], _state["longitudes"][..., mask]], axis=-1)
-            for field, values in state["fields"].items():
-                state["fields"][field] = np.concatenate([values, _state["fields"][field][..., mask]], axis=-1)
+        state: State = {key: val for key, val in states[0].items() if key not in ["latitudes", "longitudes", "fields"]}
+
+        state["latitudes"] = np.concatenate(
+            [_state["latitudes"][..., self.masks[source]] for _state, source in zip(states, sources)],
+            axis=-1,
+        )
+        state["longitudes"] = np.concatenate(
+            [_state["longitudes"][..., self.masks[source]] for _state, source in zip(states, sources)],
+            axis=-1,
+        )
+        state["fields"] = {}
+        for field in states[0]["fields"]:
+            state["fields"][field] = np.concatenate(
+                [_state["fields"][field][..., self.masks[source]] for _state, source in zip(states, sources)],
+                axis=-1,
+            )
 
         return state
 
@@ -98,16 +105,18 @@ class Cutout(Input):
         """
 
         sources = list(self.sources.keys())
-        fields = self.sources[sources[0]].load_forcings_state(
-            variables=variables, dates=dates, current_state=current_state
-        )["fields"]
-        for source in sources[1:]:
-            mask = self.masks[source]
-            _fields = self.sources[source].load_forcings_state(
-                variables=variables, dates=dates, current_state=current_state
-            )["fields"]
-            for field in fields:
-                fields[field] = np.concatenate([fields[field], _fields[field][..., mask]], axis=-1)
+        _fields = [
+            self.sources[source].load_forcings_state(variables=variables, dates=dates, current_state=current_state)[
+                "fields"
+            ]
+            for source in sources
+        ]
+        fields: dict[str, Any] = {}
+        for field_name in _fields[0]:
+            fields[field_name] = np.concatenate(
+                [_field[field_name][..., self.masks[source]] for _field, source in zip(_fields, sources)],
+                axis=-1,
+            )
 
         current_state["fields"] |= fields
         return current_state


### PR DESCRIPTION
## Description
In the Cutout input file, the mask of the first source is never applied.

## What problem does this change solve?
Previously, the mask of the first source in config.input.cutout was not applied.
For example with the following config:
```yaml
input:
  cutout:
    global:
        grib: path/to/global.grib
    lam_0:
        grib: path/to/lam_0.grib
```

The cutout mask of `global` is never applied. 
This applies the masks to all sources.

## What issue or task does this change relate to?
Fixes #248

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***
