### PR TITLE
feat: inner-level processors

### DIFF
--- a/docs/inference/configs/introduction.rst
+++ b/docs/inference/configs/introduction.rst
@@ -49,6 +49,7 @@ or if it expects a single argument, it can be simplified as:
    top-level
    inputs
    outputs
+   processors
    forcings
    icon-input
    grib-input

--- a/docs/inference/configs/processors.rst
+++ b/docs/inference/configs/processors.rst
@@ -1,0 +1,130 @@
+################
+ Pre-processors
+################
+
+There can be top-level pre-processors that are applied to all inputs
+indifferently or input-level pre-processors that are applied per-input.
+
+In terms of order, input-level pre-processors are applied first, then
+top-level ones.
+
+**************************
+ Available pre-processors
+**************************
+
+no_missing_values
+=================
+
+Replaces NaNs with the mean.
+
+forward_transform_filter
+========================
+
+Applies a filter from `anemoi-transform
+<https://anemoi.readthedocs.io/projects/transform/en/latest/_api/transform.filters.html>`_.
+
+**************************
+ Top-level pre-processors
+**************************
+
+List top-level pre-processors in ``pre_processors``:
+
+.. code:: yaml
+
+   pre_processors:
+     - forward_transform_filter: cos_sin_mean_wave_direction
+     - no_missing_values
+
+****************************
+ Input-level pre-processors
+****************************
+
+For an input like ``cutout``, you may want to apply different
+pre-processors for the different inputs. As such, some inputs (namely
+grib, mars and cds) also accept a ``pre_processors`` argument
+
+.. code:: yaml
+
+   input:
+     cutout:
+       lam_0:
+         grib:
+           path: /path/to/local.grib
+           pre_processors:
+             - forward_transform_filter: remove_nans
+       global:
+         grib:
+           path: /path/to/global.grib
+
+#################
+ Post-processors
+#################
+
+There can be top-level post-processors that are applied to all outputs
+indifferently or output-level post-processors that are applied
+per-output.
+
+In terms of order, top-level post-processors are applied first, then
+output-level ones.
+
+***************************
+ Available post-processors
+***************************
+
+accumulate_from_start_of_forecast
+=================================
+
+Accumulate fields from zero and return the accumulated fields. .. code::
+yaml
+
+.. code:: yaml
+
+   post_processors:
+     - accumulate_from_start_of_forecast
+
+will accumulate the necessary fields from the checkpoint.
+
+To specify the fields to accumulate:
+
+.. code:: yaml
+
+   post_processors:
+     - accumulate_from_start_of_forecast:
+         accumulations:
+           - tp
+
+backward_transform_filter
+=========================
+
+Applies a backward transform filter from `anemoi-transform
+<https://anemoi.readthedocs.io/projects/transform/en/latest/_api/transform.filters.html>`_.
+
+***************************
+ Top-level post-processors
+***************************
+
+List top-level post-processors in ``post_processors``:
+
+.. code:: yaml
+
+   post_processors:
+     - backward_transform_filter: cos_sin_mean_wave_direction
+     - accumulate_from_start_of_forecast
+
+******************************
+ Output-level post-processors
+******************************
+
+For an output like ``tee``, you may want to apply different
+post-processors for the different outputs. All output (except ``tee``
+and ``truth``) accept an additional ``post_processors`` argument:
+
+.. code:: yaml
+
+   output:
+     tee:
+       - netcdf: /path/to/netcdf/file.nc
+       - grib:
+           path: /path/to/grib/file.grib
+           post_processors:
+             - backward_transform_filter: cos_sin_mean_wave_direction

--- a/docs/inference/configs/top-level.rst
+++ b/docs/inference/configs/top-level.rst
@@ -83,6 +83,13 @@ and output. It set to ``null`` (default), the value is set internally to
 The entries for the inputs and outputs are specified in the :ref:`inputs
 <inputs>` and :ref:`outputs <outputs>` sections of the documentation.
 
+**************************
+ Pre- and Post-processors
+**************************
+
+The entries for the pre- and post-processors are specified in the
+:ref:`processors <processors>` section of the documentation.
+
 ***********
  Debugging
 ***********

--- a/src/anemoi/inference/config/run.py
+++ b/src/anemoi/inference/config/run.py
@@ -22,6 +22,8 @@ from . import Configuration
 
 LOG = logging.getLogger(__name__)
 
+ProcessorConfig = Union[str, Dict[str, Any]]
+
 
 class RunConfiguration(Configuration):
     """Configuration class for a default runner."""
@@ -57,8 +59,8 @@ class RunConfiguration(Configuration):
     input: Union[str, Dict[str, Any]] = "test"
     output: Union[str, Dict[str, Any]] = "printer"
 
-    pre_processors: List[Union[str, Dict[str, Any]]] = []
-    post_processors: Optional[List[Union[str, Dict[str, Any]]]] = None  # temporary, default accum from start #131
+    pre_processors: List[ProcessorConfig] = []
+    post_processors: Optional[List[ProcessorConfig]] = None  # temporary, default accum from start #131
 
     forcings: Optional[Dict[str, Dict[str, Any]]] = None
     """Where to find the forcings."""

--- a/src/anemoi/inference/input.py
+++ b/src/anemoi/inference/input.py
@@ -12,7 +12,6 @@ from abc import abstractmethod
 from functools import cached_property
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Iterable
 from typing import List
 from typing import Optional
 
@@ -37,14 +36,14 @@ class Input(ABC):
 
     trace_name = "????"  # Override in subclass
 
-    def __init__(self, context: "Context", pre_processors: Optional[Iterable[ProcessorConfig]] = None):
+    def __init__(self, context: "Context", pre_processors: Optional[List[ProcessorConfig]] = None):
         """Initialize the Input object.
 
         Parameters
         ----------
         context : Context
             The context for the input.
-        pre_processors : Optional[Iterable[ProcessorConfig]], default None
+        pre_processors : Optional[List[ProcessorConfig]], default None
             Pre-processors to apply to the input
         """
         self.context = context
@@ -64,6 +63,24 @@ class Input(ABC):
 
         LOG.info("Pre processors: %s", processors)
         return processors
+
+    def pre_process(self, x: Any) -> Any:
+        """Run pre-processors.
+
+        Parameters
+        ----------
+        x : Any
+            input to pre-process
+
+        Return
+        ------
+        Any
+            Pre-processed input
+        """
+        for processor in self.pre_processors:
+            LOG.info("Processing with %s", processor)
+            x = processor.process(x)
+        return x
 
     def __repr__(self) -> str:
         """Return a string representation of the Input object.

--- a/src/anemoi/inference/inputs/cds.py
+++ b/src/anemoi/inference/inputs/cds.py
@@ -18,6 +18,7 @@ from typing import Union
 import earthkit.data as ekd
 from earthkit.data.utils.dates import to_datetime
 
+from anemoi.inference.config.run import ProcessorConfig
 from anemoi.inference.context import Context
 from anemoi.inference.types import DataRequest
 from anemoi.inference.types import Date
@@ -113,7 +114,13 @@ class CDSInput(GribInput):
     trace_name = "cds"
 
     def __init__(
-        self, context: Context, *, dataset: Union[str, Dict[str, Any]], namer: Optional[Any] = None, **kwargs: Any
+        self,
+        context: Context,
+        pre_processors: Optional[List[ProcessorConfig]] = None,
+        *,
+        dataset: Union[str, Dict[str, Any]],
+        namer: Optional[Any] = None,
+        **kwargs: Any,
     ) -> None:
         """Initialize the CDSInput.
 
@@ -121,6 +128,8 @@ class CDSInput(GribInput):
         ----------
         context : Context
             The context in which the input is used.
+        pre_processors : Optional[List[ProcessorConfig]], default None
+            Pre-processors to apply to the input
         dataset : Union[str, Dict[str, Any]]
             The dataset to use.
         namer : Optional[Any]
@@ -128,7 +137,7 @@ class CDSInput(GribInput):
         **kwargs : Any
             Additional keyword arguments.
         """
-        super().__init__(context, namer=namer)
+        super().__init__(context, pre_processors, namer=namer)
 
         self.variables = self.checkpoint.variables_from_input(include_forcings=False)
         self.dataset = dataset

--- a/src/anemoi/inference/inputs/ekd.py
+++ b/src/anemoi/inference/inputs/ekd.py
@@ -14,6 +14,7 @@ from collections import defaultdict
 from typing import Any
 from typing import Callable
 from typing import Dict
+from typing import Iterable
 from typing import List
 from typing import Optional
 from typing import Union
@@ -24,6 +25,7 @@ from earthkit.data.indexing.fieldlist import FieldArray
 from earthkit.data.utils.dates import to_datetime
 from numpy.typing import DTypeLike
 
+from anemoi.inference.config.run import ProcessorConfig
 from anemoi.inference.context import Context
 from anemoi.inference.types import Date
 from anemoi.inference.types import FloatArray
@@ -105,6 +107,7 @@ class EkdInput(Input):
     def __init__(
         self,
         context: Context,
+        pre_processors: Optional[Iterable[ProcessorConfig]] = None,
         *,
         namer: Optional[Union[Callable[[Any, Dict[str, Any]], str], Dict[str, Any]]] = None,
     ) -> None:
@@ -117,7 +120,7 @@ class EkdInput(Input):
         namer : Optional[Union[Callable[[Any, Dict[str, Any]], str], Dict[str, Any]]]
             Optional namer for the input.
         """
-        super().__init__(context)
+        super().__init__(context, pre_processors)
 
         if isinstance(namer, dict):
             # TODO: a factory for namers
@@ -229,7 +232,7 @@ class EkdInput(Input):
         State
             The created input state.
         """
-        for processor in self.context.pre_processors:
+        for processor in self.pre_processors:
             LOG.info("Processing with %s", processor)
             fields = processor.process(fields)
 
@@ -406,7 +409,7 @@ class EkdInput(Input):
         State
             The loaded forcings state.
         """
-        for processor in self.context.pre_processors:
+        for processor in self.pre_processors:
             LOG.info("Processing with %s", processor)
             fields = processor.process(fields)
 

--- a/src/anemoi/inference/inputs/ekd.py
+++ b/src/anemoi/inference/inputs/ekd.py
@@ -14,7 +14,6 @@ from collections import defaultdict
 from typing import Any
 from typing import Callable
 from typing import Dict
-from typing import Iterable
 from typing import List
 from typing import Optional
 from typing import Union
@@ -107,7 +106,7 @@ class EkdInput(Input):
     def __init__(
         self,
         context: Context,
-        pre_processors: Optional[Iterable[ProcessorConfig]] = None,
+        pre_processors: Optional[List[ProcessorConfig]] = None,
         *,
         namer: Optional[Union[Callable[[Any, Dict[str, Any]], str], Dict[str, Any]]] = None,
     ) -> None:
@@ -117,6 +116,8 @@ class EkdInput(Input):
         ----------
         context : Any
             The context in which the input is used.
+        pre_processors : Optional[List[ProcessorConfig]], default None
+            Pre-processors to apply to the input
         namer : Optional[Union[Callable[[Any, Dict[str, Any]], str], Dict[str, Any]]]
             Optional namer for the input.
         """
@@ -232,9 +233,7 @@ class EkdInput(Input):
         State
             The created input state.
         """
-        for processor in self.pre_processors:
-            LOG.info("Processing with %s", processor)
-            fields = processor.process(fields)
+        fields = self.pre_process(fields)
 
         if variables is None:
             variables = self.checkpoint.variables_from_input(include_forcings=True)
@@ -409,10 +408,6 @@ class EkdInput(Input):
         State
             The loaded forcings state.
         """
-        for processor in self.pre_processors:
-            LOG.info("Processing with %s", processor)
-            fields = processor.process(fields)
-
         return self._create_state(
             fields,
             variables=variables,

--- a/src/anemoi/inference/inputs/fdb.py
+++ b/src/anemoi/inference/inputs/fdb.py
@@ -16,6 +16,8 @@ from typing import Optional
 import earthkit.data as ekd
 import numpy as np
 
+from anemoi.inference.config.run import ProcessorConfig
+
 from ..types import Date
 from ..types import State
 from . import input_registry
@@ -33,6 +35,7 @@ class FDBInput(GribInput):
     def __init__(
         self,
         context,
+        pre_processors: Optional[List[ProcessorConfig]] = None,
         *,
         namer=None,
         fdb_config: dict | None = None,
@@ -45,6 +48,8 @@ class FDBInput(GribInput):
         ----------
         context : dict
             The context runner.
+        pre_processors : Optional[List[ProcessorConfig]], default None
+            Pre-processors to apply to the input
         namer : optional
             The namer to use for the input.
         fdb_config : dict, optional
@@ -54,7 +59,7 @@ class FDBInput(GribInput):
         kwargs : dict, optional
             Additional keyword arguments for the request to FDB.
         """
-        super().__init__(context, namer=namer)
+        super().__init__(context, pre_processors, namer=namer)
         self.kwargs = kwargs
         self.configs = {"config": fdb_config, "userconfig": fdb_userconfig}
         # NOTE: this is a temporary workaround for #191 thus not documented

--- a/src/anemoi/inference/inputs/gribfile.py
+++ b/src/anemoi/inference/inputs/gribfile.py
@@ -15,6 +15,7 @@ from typing import Optional
 
 import earthkit.data as ekd
 
+from anemoi.inference.config.run import ProcessorConfig
 from anemoi.inference.context import Context
 from anemoi.inference.types import Date
 from anemoi.inference.types import State
@@ -33,7 +34,15 @@ class GribFileInput(GribInput):
 
     trace_name = "grib file"
 
-    def __init__(self, context: Context, path: str, *, namer: Optional[Any] = None, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        context: Context,
+        path: str,
+        pre_processors: Optional[List[ProcessorConfig]] = None,
+        *,
+        namer: Optional[Any] = None,
+        **kwargs: Any,
+    ) -> None:
         """Initialize the GribFileInput.
 
         Parameters
@@ -42,12 +51,14 @@ class GribFileInput(GribInput):
             The context in which the input is used.
         path : str
             The path to the GRIB file.
+        pre_processors : Optional[List[ProcessorConfig]], default None
+            Pre-processors to apply to the input
         namer : Optional[Any]
             Optional namer for the input.
         **kwargs : Any
             Additional keyword arguments.
         """
-        super().__init__(context, namer=namer, **kwargs)
+        super().__init__(context, pre_processors, namer=namer, **kwargs)
         self.path = path
 
     def create_input_state(self, *, date: Optional[Date]) -> State:

--- a/src/anemoi/inference/inputs/icon.py
+++ b/src/anemoi/inference/inputs/icon.py
@@ -15,6 +15,7 @@ from typing import Optional
 
 import earthkit.data as ekd
 
+from anemoi.inference.config.run import ProcessorConfig
 from anemoi.inference.context import Context
 from anemoi.inference.types import Date
 from anemoi.inference.types import State
@@ -39,6 +40,7 @@ class IconInput(GribInput):
         path: str,
         grid: str,
         refinement_level_c: int,
+        pre_processors: Optional[List[ProcessorConfig]] = None,
         namer: Optional[Any] = None,
         **kwargs: Any,
     ) -> None:
@@ -54,12 +56,14 @@ class IconInput(GribInput):
             The grid type.
         refinement_level_c : int
             The refinement level.
+        pre_processors : Optional[List[ProcessorConfig]], default None
+            Pre-processors to apply to the input
         namer : Optional[Any]
             Optional namer for the input.
         **kwargs : Any
             Additional keyword arguments.
         """
-        super().__init__(context, namer=namer, **kwargs)
+        super().__init__(context, pre_processors, namer=namer, **kwargs)
         self.path = path
         self.grid = grid
         self.refinement_level_c = refinement_level_c

--- a/src/anemoi/inference/inputs/mars.py
+++ b/src/anemoi/inference/inputs/mars.py
@@ -18,6 +18,7 @@ from typing import Union
 
 from earthkit.data.utils.dates import to_datetime
 
+from anemoi.inference.config.run import ProcessorConfig
 from anemoi.inference.context import Context
 from anemoi.inference.types import DataRequest
 from anemoi.inference.types import Date
@@ -206,6 +207,7 @@ class MarsInput(GribInput):
     def __init__(
         self,
         context: Context,
+        pre_processors: Optional[List[ProcessorConfig]] = None,
         *,
         namer: Optional[Any] = None,
         patches: Optional[List[Tuple[Dict[str, Any], Dict[str, Any]]]] = None,
@@ -224,7 +226,7 @@ class MarsInput(GribInput):
         **kwargs : Any
             Additional keyword to pass to the request to MARS.
         """
-        super().__init__(context, namer=namer)
+        super().__init__(context, pre_processors, namer=namer)
         self.kwargs = kwargs
         self.variables = self.checkpoint.variables_from_input(include_forcings=False)
         self.kwargs = kwargs

--- a/src/anemoi/inference/output.py
+++ b/src/anemoi/inference/output.py
@@ -12,8 +12,12 @@ from abc import ABC
 from abc import abstractmethod
 from functools import cached_property
 from typing import TYPE_CHECKING
+from typing import List
 from typing import Optional
 
+from anemoi.inference.config.run import ProcessorConfig
+from anemoi.inference.post_processors import create_post_processor
+from anemoi.inference.processor import Processor
 from anemoi.inference.types import State
 
 if TYPE_CHECKING:
@@ -28,6 +32,7 @@ class Output(ABC):
     def __init__(
         self,
         context: "Context",
+        post_processors: Optional[List[ProcessorConfig]] = None,
         output_frequency: Optional[int] = None,
         write_initial_state: Optional[bool] = None,
     ):
@@ -37,6 +42,8 @@ class Output(ABC):
         ----------
         context : Context
             The context in which the output operates.
+        post_processors : Optional[List[ProcessorConfig]], default None
+            Post-processors to apply to the input
         output_frequency : Optional[int], optional
             The frequency at which to output states, by default None.
         write_initial_state : Optional[bool], optional
@@ -46,8 +53,42 @@ class Output(ABC):
         self.checkpoint = context.checkpoint
         self.reference_date = None
 
+        self._post_processor_confs = post_processors or []
+
         self._write_step_zero = write_initial_state
         self._output_frequency = output_frequency
+
+    @cached_property
+    def post_processors(self) -> List[Processor]:
+        """Return post-processors."""
+
+        processors = []
+
+        if hasattr(self.context, "post_processors"):
+            processors.extend(self.context.post_processors)
+
+        for processor in self._post_processor_confs:
+            processors.append(create_post_processor(self.context, processor))
+
+        return processors
+
+    def post_process(self, state: State) -> State:
+        """Apply post processors to the state.
+
+        Parameters
+        ----------
+        state : State
+            The state.
+
+        Returns
+        -------
+        State
+            The processed state.
+        """
+        for processor in self.post_processors:
+            LOG.info("Post processor: %s", processor)
+            state = processor.process(state)
+        return state
 
     def __repr__(self) -> str:
         """Return a string representation of the Output object.
@@ -69,7 +110,7 @@ class Output(ABC):
         """
         state.setdefault("step", datetime.timedelta(0))
         if self.write_step_zero:
-            self.write_step(state)
+            self.write_step(self.post_process(state))
 
     def write_state(self, state: State) -> None:
         """Write the state.
@@ -84,7 +125,7 @@ class Output(ABC):
             if (step % self.output_frequency).total_seconds() != 0:
                 return
 
-        return self.write_step(state)
+        return self.write_step(self.post_process(state))
 
     @classmethod
     def reduce(cls, state: State) -> State:
@@ -181,6 +222,7 @@ class ForwardOutput(Output):
         self,
         context: "Context",
         output: dict,
+        post_processors: Optional[List[ProcessorConfig]] = None,
         output_frequency: Optional[int] = None,
         write_initial_state: Optional[bool] = None,
     ):
@@ -192,6 +234,8 @@ class ForwardOutput(Output):
             The context in which the output operates.
         output : dict
             The output configuration dictionary.
+        post_processors : Optional[List[ProcessorConfig]], default None
+            Post-processors to apply to the input
         output_frequency : Optional[int], optional
             The frequency at which to output states, by default None.
         write_initial_state : Optional[bool], optional
@@ -200,7 +244,7 @@ class ForwardOutput(Output):
 
         from anemoi.inference.outputs import create_output
 
-        super().__init__(context, output_frequency=None, write_initial_state=write_initial_state)
+        super().__init__(context, post_processors, output_frequency=None, write_initial_state=write_initial_state)
 
         self.output = None if output is None else create_output(context, output)
 

--- a/src/anemoi/inference/outputs/apply_mask.py
+++ b/src/anemoi/inference/outputs/apply_mask.py
@@ -8,9 +8,11 @@
 # nor does it submit to any jurisdiction.
 
 import logging
+from typing import List
 from typing import Optional
 
 from anemoi.inference.config import Configuration
+from anemoi.inference.config.run import ProcessorConfig
 from anemoi.inference.context import Context
 
 from . import output_registry
@@ -31,6 +33,8 @@ class ApplyMaskOutput(MaskedOutput):
         The mask identifier.
     output : dict
         The output configuration dictionary.
+    post_processors : Optional[List[ProcessorConfig]], default None
+        Post-processors to apply to the input
     output_frequency : int, optional
         The frequency of output, by default None.
     write_initial_state : bool, optional
@@ -43,6 +47,7 @@ class ApplyMaskOutput(MaskedOutput):
         *,
         mask: str,
         output: Configuration,
+        post_processors: Optional[List[ProcessorConfig]] = None,
         output_frequency: Optional[int] = None,
         write_initial_state: Optional[bool] = None,
     ) -> None:
@@ -50,6 +55,7 @@ class ApplyMaskOutput(MaskedOutput):
             context,
             mask=context.checkpoint.load_supporting_array(mask),
             output=output,
+            post_processors=post_processors,
             output_frequency=output_frequency,
             write_initial_state=write_initial_state,
         )

--- a/src/anemoi/inference/outputs/assign_mask.py
+++ b/src/anemoi/inference/outputs/assign_mask.py
@@ -8,11 +8,13 @@
 # nor does it submit to any jurisdiction.
 
 import logging
+from typing import List
 from typing import Optional
 
 import numpy as np
 
 from anemoi.inference.config import Configuration
+from anemoi.inference.config.run import ProcessorConfig
 from anemoi.inference.context import Context
 from anemoi.inference.types import State
 
@@ -43,6 +45,8 @@ class AssignMask(ForwardOutput):
         The mask supporting array name.
     fill_value : float, optional
         The fill value to use for the masked area, by default np.nan.
+    post_processors : Optional[List[ProcessorConfig]], default None
+        Post-processors to apply to the input
     output_frequency : int, optional
         The frequency of output, by default None.
     write_initial_state : bool, optional
@@ -56,10 +60,13 @@ class AssignMask(ForwardOutput):
         output: Configuration,
         mask: str,
         fill_value: float = np.nan,
+        post_processors: Optional[List[ProcessorConfig]] = None,
         output_frequency: Optional[int] = None,
         write_initial_state: Optional[bool] = None,
     ) -> None:
-        super().__init__(context, output, output_frequency=output_frequency, write_initial_state=write_initial_state)
+        super().__init__(
+            context, output, post_processors, output_frequency=output_frequency, write_initial_state=write_initial_state
+        )
 
         if mask not in self.checkpoint.supporting_arrays:
             raise ValueError(f"Assignment mask '{mask}' not found in supporting arrays.")

--- a/src/anemoi/inference/outputs/extract_lam.py
+++ b/src/anemoi/inference/outputs/extract_lam.py
@@ -8,11 +8,13 @@
 # nor does it submit to any jurisdiction.
 
 import logging
+from typing import List
 from typing import Optional
 
 import numpy as np
 
 from anemoi.inference.config import Configuration
+from anemoi.inference.config.run import ProcessorConfig
 from anemoi.inference.context import Context
 
 from . import output_registry
@@ -33,6 +35,8 @@ class ExtractLamOutput(MaskedOutput):
         The output configuration dictionary.
     lam : str, optional
         The LAM identifier, by default "lam_0".
+    post_processors : Optional[List[ProcessorConfig]], default None
+        Post-processors to apply to the input
     output_frequency : int, optional
         The frequency of output, by default None.
     write_initial_state : bool, optional
@@ -45,10 +49,10 @@ class ExtractLamOutput(MaskedOutput):
         *,
         output: Configuration,
         lam: str = "lam_0",
+        post_processors: Optional[List[ProcessorConfig]] = None,
         output_frequency: Optional[int] = None,
         write_initial_state: Optional[bool] = None,
     ) -> None:
-
         if "cutout_mask" in context.checkpoint.supporting_arrays:
             # Backwards compatibility
             mask = context.checkpoint.load_supporting_array("cutout_mask")
@@ -69,6 +73,7 @@ class ExtractLamOutput(MaskedOutput):
             context,
             mask=points,
             output=output,
+            post_processors=post_processors,
             output_frequency=output_frequency,
             write_initial_state=write_initial_state,
         )

--- a/src/anemoi/inference/outputs/grib.py
+++ b/src/anemoi/inference/outputs/grib.py
@@ -20,6 +20,7 @@ from typing import Union
 
 from earthkit.data.utils.dates import to_datetime
 
+from anemoi.inference.config.run import ProcessorConfig
 from anemoi.inference.types import FloatArray
 from anemoi.inference.types import State
 
@@ -119,6 +120,7 @@ class GribOutput(Output):
     def __init__(
         self,
         context: dict,
+        post_processors: Optional[List[ProcessorConfig]] = None,
         *,
         encoding: Optional[Dict[str, Any]] = None,
         templates: Optional[Union[List[str], str]] = None,
@@ -135,6 +137,8 @@ class GribOutput(Output):
         ----------
         context : dict
             The context dictionary.
+        post_processors : Optional[List[ProcessorConfig]] = None
+            Post-processors to apply to the input
         encoding : dict, optional
             The encoding dictionary, by default None.
         templates : list or str, optional
@@ -153,7 +157,9 @@ class GribOutput(Output):
             The list of variables, by default None.
         """
 
-        super().__init__(context, output_frequency=output_frequency, write_initial_state=write_initial_state)
+        super().__init__(
+            context, post_processors, output_frequency=output_frequency, write_initial_state=write_initial_state
+        )
         self._first = True
         self.typed_variables = self.checkpoint.typed_variables
         self.encoding = encoding if encoding is not None else {}
@@ -219,7 +225,7 @@ class GribOutput(Output):
                     f"No grib template found for initial state param `{name}`. Try setting `write_initial_state` to `false`."
                 )
 
-        return self.write_step(state)
+        return self.write_step(self.post_process(state))
 
     def write_step(self, state: State) -> None:
         """Write a step of the state.

--- a/src/anemoi/inference/outputs/gribfile.py
+++ b/src/anemoi/inference/outputs/gribfile.py
@@ -20,6 +20,7 @@ from typing import Union
 import earthkit.data as ekd
 import numpy as np
 
+from anemoi.inference.config.run import ProcessorConfig
 from anemoi.inference.context import Context
 from anemoi.inference.types import DataRequest
 from anemoi.inference.types import FloatArray
@@ -113,6 +114,7 @@ class GribFileOutput(GribOutput):
     def __init__(
         self,
         context: Context,
+        post_processors: Optional[List[ProcessorConfig]] = None,
         *,
         path: str,
         encoding: Optional[Dict[str, Any]] = None,
@@ -133,6 +135,8 @@ class GribFileOutput(GribOutput):
         ----------
         context : Context
             The context.
+        post_processors : Optional[List[ProcessorConfig]], default None
+            Post-processors to apply to the input
         path : str
             The path to save the grib files.
         encoding : dict, optional
@@ -160,6 +164,7 @@ class GribFileOutput(GribOutput):
         """
         super().__init__(
             context,
+            post_processors,
             encoding=encoding,
             templates=templates,
             grib1_keys=grib1_keys,
@@ -246,7 +251,6 @@ class GribFileOutput(GribOutput):
         handle, path = written
 
         while True:
-
             if self._namespace_bug_fix:
                 import eccodes
                 from earthkit.data.readers.grib.codes import GribCodesHandle

--- a/src/anemoi/inference/outputs/masked.py
+++ b/src/anemoi/inference/outputs/masked.py
@@ -9,9 +9,11 @@
 
 import logging
 from typing import Any
+from typing import List
 from typing import Optional
 
 from anemoi.inference.config import Configuration
+from anemoi.inference.config.run import ProcessorConfig
 from anemoi.inference.context import Context
 from anemoi.inference.types import State
 
@@ -31,6 +33,8 @@ class MaskedOutput(ForwardOutput):
         The mask.
     output : dict
         The output configuration dictionary.
+    post_processors : Optional[List[ProcessorConfig]], default None
+        Post-processors to apply to the input
     output_frequency : int, optional
         The frequency of output, by default None.
     write_initial_state : bool, optional
@@ -43,10 +47,13 @@ class MaskedOutput(ForwardOutput):
         *,
         mask: Any,
         output: Configuration,
+        post_processors: Optional[List[ProcessorConfig]] = None,
         output_frequency: Optional[int] = None,
         write_initial_state: Optional[bool] = None,
     ) -> None:
-        super().__init__(context, output, output_frequency=output_frequency, write_initial_state=write_initial_state)
+        super().__init__(
+            context, output, post_processors, output_frequency=output_frequency, write_initial_state=write_initial_state
+        )
         self.mask = mask
 
     def modify_state(self, state: State) -> State:

--- a/src/anemoi/inference/outputs/netcdf.py
+++ b/src/anemoi/inference/outputs/netcdf.py
@@ -10,10 +10,12 @@
 import logging
 import os
 import threading
+from typing import List
 from typing import Optional
 
 import numpy as np
 
+from anemoi.inference.config.run import ProcessorConfig
 from anemoi.inference.context import Context
 from anemoi.inference.types import State
 
@@ -37,6 +39,7 @@ class NetCDFOutput(Output):
         self,
         context: Context,
         path: str,
+        post_processors: Optional[List[ProcessorConfig]] = None,
         output_frequency: Optional[int] = None,
         write_initial_state: Optional[bool] = None,
         float_size: str = "f4",
@@ -50,6 +53,8 @@ class NetCDFOutput(Output):
             The context dictionary.
         path : str
             The path to save the NetCDF file.
+        post_processors : Optional[List[ProcessorConfig]], default None
+            Post-processors to apply to the input
         output_frequency : int, optional
             The frequency of output, by default None.
         write_initial_state : bool, optional
@@ -60,7 +65,9 @@ class NetCDFOutput(Output):
             The missing value, by default np.nan.
         """
 
-        super().__init__(context, output_frequency=output_frequency, write_initial_state=write_initial_state)
+        super().__init__(
+            context, post_processors, output_frequency=output_frequency, write_initial_state=write_initial_state
+        )
 
         from netCDF4 import Dataset
 

--- a/src/anemoi/inference/outputs/plot.py
+++ b/src/anemoi/inference/outputs/plot.py
@@ -16,6 +16,7 @@ from typing import Union
 
 import numpy as np
 
+from anemoi.inference.config.run import ProcessorConfig
 from anemoi.inference.context import Context
 from anemoi.inference.types import FloatArray
 from anemoi.inference.types import State
@@ -58,6 +59,7 @@ class PlotOutput(Output):
         dpi: int = 300,
         format: str = "png",
         missing_value: Optional[float] = None,
+        post_processors: Optional[List[ProcessorConfig]] = None,
         output_frequency: Optional[int] = None,
         write_initial_state: Optional[bool] = None,
     ) -> None:
@@ -81,13 +83,17 @@ class PlotOutput(Output):
             The format of the plot, by default "png".
         missing_value : float, optional
             The value to use for missing data, by default None.
+        post_processors : Optional[List[ProcessorConfig]], default None
+            Post-processors to apply to the input
         output_frequency : int, optional
             The frequency of output, by default None.
         write_initial_state : bool, optional
             Whether to write the initial state, by default None.
         """
 
-        super().__init__(context, output_frequency=output_frequency, write_initial_state=write_initial_state)
+        super().__init__(
+            context, post_processors, output_frequency=output_frequency, write_initial_state=write_initial_state
+        )
         self.path = path
         self.format = format
         self.variables = variables
@@ -120,7 +126,6 @@ class PlotOutput(Output):
         triangulation = tri.Triangulation(fix(longitudes), latitudes)
 
         for name, values in state["fields"].items():
-
             if self.variables != "all" and name not in self.variables:
                 continue
 

--- a/src/anemoi/inference/outputs/printer.py
+++ b/src/anemoi/inference/outputs/printer.py
@@ -19,6 +19,7 @@ from typing import Union
 
 import numpy as np
 
+from anemoi.inference.config.run import ProcessorConfig
 from anemoi.inference.context import Context
 from anemoi.inference.types import State
 
@@ -53,7 +54,6 @@ def print_state(
     print()
     print("😀", end=" ")
     for key, value in state.items():
-
         if isinstance(value, datetime.datetime):
             print(f"{key}={value.isoformat()}", end=" ")
 
@@ -113,6 +113,7 @@ class PrinterOutput(Output):
     def __init__(
         self,
         context: Context,
+        post_processors: Optional[List[ProcessorConfig]] = None,
         path: Optional[str] = None,
         variables: Optional[ListOrAll] = None,
         **kwargs: Any,
@@ -123,6 +124,8 @@ class PrinterOutput(Output):
         ----------
         context : Context
             The context.
+        post_processors : Optional[List[ProcessorConfig]] = None
+            Post-processors to apply to the input
         path : str, optional
             The path to save the printed output, by default None.
         variables : list, optional
@@ -131,7 +134,7 @@ class PrinterOutput(Output):
             Additional keyword arguments.
         """
 
-        super().__init__(context)
+        super().__init__(context, post_processors)
         self.print = print
         self.variables = variables
 

--- a/src/anemoi/inference/outputs/raw.py
+++ b/src/anemoi/inference/outputs/raw.py
@@ -9,10 +9,12 @@
 
 import logging
 import os
+from typing import List
 from typing import Optional
 
 import numpy as np
 
+from anemoi.inference.config.run import ProcessorConfig
 from anemoi.inference.context import Context
 from anemoi.inference.types import State
 
@@ -34,6 +36,7 @@ class RawOutput(Output):
         path: str,
         template: str = "{date}.npz",
         strftime: str = "%Y%m%d%H%M%S",
+        post_processors: Optional[List[ProcessorConfig]] = None,
         output_frequency: Optional[int] = None,
         write_initial_state: Optional[bool] = None,
     ) -> None:
@@ -49,12 +52,16 @@ class RawOutput(Output):
             The template for filenames, by default "{date}.npz".
         strftime : str, optional
             The date format string, by default "%Y%m%d%H%M%S".
+        post_processors : Optional[List[ProcessorConfig]], default None
+            Post-processors to apply to the input
         output_frequency : int, optional
             The frequency of output, by default None.
         write_initial_state : bool, optional
             Whether to write the initial state, by default None.
         """
-        super().__init__(context, output_frequency=output_frequency, write_initial_state=write_initial_state)
+        super().__init__(
+            context, post_processors, output_frequency=output_frequency, write_initial_state=write_initial_state
+        )
         self.path = path
         self.template = template
         self.strftime = strftime

--- a/src/anemoi/inference/outputs/tee.py
+++ b/src/anemoi/inference/outputs/tee.py
@@ -14,6 +14,7 @@ from typing import List
 from typing import Optional
 
 from anemoi.inference.config import Configuration
+from anemoi.inference.config.run import ProcessorConfig
 from anemoi.inference.context import Context
 from anemoi.inference.types import State
 
@@ -33,6 +34,7 @@ class TeeOutput(ForwardOutput):
         context: Context,
         *args: Any,
         outputs: List[Configuration],
+        post_processors: Optional[List[ProcessorConfig]] = None,
         output_frequency: Optional[int] = None,
         write_initial_state: Optional[bool] = None,
         **kwargs: Any,
@@ -47,6 +49,8 @@ class TeeOutput(ForwardOutput):
             Additional positional arguments.
         outputs : list or tuple, optional
             List of outputs to be created.
+        post_processors : Optional[List[ProcessorConfig]], default None
+            Post-processors to apply to the input
         output_frequency : int, optional
             Frequency of output.
         write_initial_state : bool, optional
@@ -54,7 +58,12 @@ class TeeOutput(ForwardOutput):
         **kwargs : Any
             Additional keyword arguments.
         """
-        super().__init__(context, None, output_frequency=output_frequency, write_initial_state=write_initial_state)
+        if post_processors is not None:
+            LOG.warning("TeeOutput does not execute post-processes. Set them to its outputs instead.")
+
+        super().__init__(
+            context, None, None, output_frequency=output_frequency, write_initial_state=write_initial_state
+        )
 
         if outputs is None:
             outputs = args

--- a/src/anemoi/inference/outputs/tee.py
+++ b/src/anemoi/inference/outputs/tee.py
@@ -14,7 +14,6 @@ from typing import List
 from typing import Optional
 
 from anemoi.inference.config import Configuration
-from anemoi.inference.config.run import ProcessorConfig
 from anemoi.inference.context import Context
 from anemoi.inference.types import State
 
@@ -34,7 +33,6 @@ class TeeOutput(ForwardOutput):
         context: Context,
         *args: Any,
         outputs: List[Configuration],
-        post_processors: Optional[List[ProcessorConfig]] = None,
         output_frequency: Optional[int] = None,
         write_initial_state: Optional[bool] = None,
         **kwargs: Any,
@@ -49,8 +47,6 @@ class TeeOutput(ForwardOutput):
             Additional positional arguments.
         outputs : list or tuple, optional
             List of outputs to be created.
-        post_processors : Optional[List[ProcessorConfig]], default None
-            Post-processors to apply to the input
         output_frequency : int, optional
             Frequency of output.
         write_initial_state : bool, optional
@@ -58,9 +54,6 @@ class TeeOutput(ForwardOutput):
         **kwargs : Any
             Additional keyword arguments.
         """
-        if post_processors is not None:
-            LOG.warning("TeeOutput does not execute post-processes. Set them to its outputs instead.")
-
         super().__init__(
             context, None, None, output_frequency=output_frequency, write_initial_state=write_initial_state
         )

--- a/src/anemoi/inference/outputs/truth.py
+++ b/src/anemoi/inference/outputs/truth.py
@@ -9,11 +9,8 @@
 
 import logging
 from typing import Any
-from typing import List
-from typing import Optional
 
 from anemoi.inference.config import Configuration
-from anemoi.inference.config.run import ProcessorConfig
 from anemoi.inference.types import State
 
 from ..context import Context
@@ -31,13 +28,7 @@ class TruthOutput(ForwardOutput):
     the forecasts, effectively only for times in the past.
     """
 
-    def __init__(
-        self,
-        context: Context,
-        output: Configuration,
-        post_processors: Optional[List[ProcessorConfig]] = None,
-        **kwargs: Any,
-    ) -> None:
+    def __init__(self, context: Context, output: Configuration, **kwargs: Any) -> None:
         """Initialize the TruthOutput.
 
         Parameters
@@ -46,15 +37,10 @@ class TruthOutput(ForwardOutput):
             The context for the output.
         output : Configuration
             The output configuration.
-        post_processors : Optional[List[ProcessorConfig]], default None
-            Post-processors to apply to the input
         kwargs : dict
             Additional keyword arguments.
         """
-        if len(post_processors):
-            LOG.warning("TruthOutput does not execute post-processes. Set it in its output instead.")
-
-        super().__init__(context, output, [], **kwargs)
+        super().__init__(context, output, None, **kwargs)
         self._input = self.context.create_input()
 
     def write_step(self, state: State) -> None:

--- a/src/anemoi/inference/outputs/truth.py
+++ b/src/anemoi/inference/outputs/truth.py
@@ -9,8 +9,11 @@
 
 import logging
 from typing import Any
+from typing import List
+from typing import Optional
 
 from anemoi.inference.config import Configuration
+from anemoi.inference.config.run import ProcessorConfig
 from anemoi.inference.types import State
 
 from ..context import Context
@@ -28,7 +31,13 @@ class TruthOutput(ForwardOutput):
     the forecasts, effectively only for times in the past.
     """
 
-    def __init__(self, context: Context, output: Configuration, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        context: Context,
+        output: Configuration,
+        post_processors: Optional[List[ProcessorConfig]] = None,
+        **kwargs: Any,
+    ) -> None:
         """Initialize the TruthOutput.
 
         Parameters
@@ -37,10 +46,15 @@ class TruthOutput(ForwardOutput):
             The context for the output.
         output : Configuration
             The output configuration.
+        post_processors : Optional[List[ProcessorConfig]], default None
+            Post-processors to apply to the input
         kwargs : dict
             Additional keyword arguments.
         """
-        super().__init__(context, output, **kwargs)
+        if len(post_processors):
+            LOG.warning("TruthOutput does not execute post-processes. Set it in its output instead.")
+
+        super().__init__(context, output, [], **kwargs)
         self._input = self.context.create_input()
 
     def write_step(self, state: State) -> None:

--- a/src/anemoi/inference/post_processors/__init__.py
+++ b/src/anemoi/inference/post_processors/__init__.py
@@ -10,14 +10,14 @@
 
 from anemoi.utils.registry import Registry
 
-from anemoi.inference.config import Configuration
+from anemoi.inference.config.run import ProcessorConfig
 from anemoi.inference.context import Context
 from anemoi.inference.processor import Processor
 
 post_processor_registry = Registry(__name__)
 
 
-def create_post_processor(context: Context, config: Configuration) -> Processor:
+def create_post_processor(context: Context, config: ProcessorConfig) -> Processor:
     """Create a post-processor.
 
     Parameters

--- a/src/anemoi/inference/pre_processors/__init__.py
+++ b/src/anemoi/inference/pre_processors/__init__.py
@@ -9,14 +9,14 @@
 
 from anemoi.utils.registry import Registry
 
-from anemoi.inference.config import Configuration
+from anemoi.inference.config.run import ProcessorType
 from anemoi.inference.context import Context
 from anemoi.inference.processor import Processor
 
 pre_processor_registry = Registry(__name__)
 
 
-def create_pre_processor(context: Context, config: Configuration) -> Processor:
+def create_pre_processor(context: Context, config: ProcessorType) -> Processor:
     """Create a pre-processor.
 
     Parameters

--- a/src/anemoi/inference/pre_processors/__init__.py
+++ b/src/anemoi/inference/pre_processors/__init__.py
@@ -9,14 +9,14 @@
 
 from anemoi.utils.registry import Registry
 
-from anemoi.inference.config.run import ProcessorType
+from anemoi.inference.config.run import ProcessorConfig
 from anemoi.inference.context import Context
 from anemoi.inference.processor import Processor
 
 pre_processor_registry = Registry(__name__)
 
 
-def create_pre_processor(context: Context, config: ProcessorType) -> Processor:
+def create_pre_processor(context: Context, config: ProcessorConfig) -> Processor:
     """Create a pre-processor.
 
     Parameters

--- a/src/anemoi/inference/runners/default.py
+++ b/src/anemoi/inference/runners/default.py
@@ -96,7 +96,6 @@ class DefaultRunner(Runner):
         input = self.create_input()
         output = self.create_output()
 
-        # pre_processors = self.pre_processors
         post_processors = self.post_processors
 
         input_state = input.create_input_state(date=self.config.date)

--- a/src/anemoi/inference/runners/default.py
+++ b/src/anemoi/inference/runners/default.py
@@ -96,24 +96,17 @@ class DefaultRunner(Runner):
         input = self.create_input()
         output = self.create_output()
 
-        post_processors = self.post_processors
-
         input_state = input.create_input_state(date=self.config.date)
 
         # This hook is needed for the coupled runner
         self.input_state_hook(input_state)
 
         state = Output.reduce(input_state)
-        for processor in post_processors:
-            state = processor.process(state)
 
         output.open(state)
         output.write_initial_state(state)
 
         for state in self.run(input_state=input_state, lead_time=lead_time):
-            for processor in post_processors:
-                LOG.info("Post processor: %s", processor)
-                state = processor.process(state)
             output.write_state(state)
 
         output.close()


### PR DESCRIPTION
## Description
Introduces input-level pre-processors and output-level post-processors.

## What problem does this change solve?
Currently, the pre-processors are created by the runner and they are used indifferently on all input sources.

This is problematic in the case of a cutout where we might want different pre-processors for the different sources (e.g. use remove_nans for the local source and nothing for the global source).

Similarly for post-processors when using the `tee` output.

## What issue or task does this change relate to?
Fixes #251.

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***
