### PR TITLE
feat!: Stop accumulating from start of forecast by default

### DIFF
--- a/src/anemoi/inference/config/run.py
+++ b/src/anemoi/inference/config/run.py
@@ -60,7 +60,7 @@ class RunConfiguration(Configuration):
     output: Union[str, Dict[str, Any]] = "printer"
 
     pre_processors: List[Union[str, Dict[str, Any]]] = []
-    post_processors: Optional[List[Union[str, Dict[str, Any]]]] = None  # temporary, default accum from start #131
+    post_processors: List[Union[str, Dict[str, Any]]] = []
 
     forcings: Optional[Dict[str, Dict[str, Any]]] = None
     """Where to find the forcings."""

--- a/src/anemoi/inference/runners/default.py
+++ b/src/anemoi/inference/runners/default.py
@@ -9,7 +9,6 @@
 
 
 import logging
-import warnings
 from typing import Any
 from typing import Dict
 from typing import List
@@ -121,6 +120,15 @@ class DefaultRunner(Runner):
             output.write_state(state)
 
         output.close()
+
+        if "accumulate_from_start_of_forecast" not in self.config.post_processors:
+            LOG.warning(
+                """
+                🚧 The default accumulation behaviour has changed. 🚧
+                🚧 Accumulation fields have NOT been accumulated from the beginning of the forecast. 🚧
+                🚧 To accumulate from the beginning, set `post_processors: [accumulate_from_start_of_forecast]` 🚧
+                """  # ecmwf/anemoi-inference#131
+            )
 
     def input_state_hook(self, input_state: State) -> None:
         """Hook used by coupled runners to send the input state."""
@@ -281,26 +289,6 @@ class DefaultRunner(Runner):
         List[Processor]
             The created pre-processors.
         """
-        if self.config.post_processors is None:
-            self.config.post_processors = ["accumulate_from_start_of_forecast"]
-            warnings.warn(
-                """
-                No post_processors defined. Accumulations will be accumulated from the beginning of the forecast.
-
-                🚧🚧🚧 In a future release, the default will be to NOT accumulate from the beginning of the forecast. 🚧🚧🚧
-                Update your config if you wish to keep accumulating from the beginning.
-                https://github.com/ecmwf/anemoi-inference/issues/131
-                """,
-            )
-
-        if "accumulate_from_start_of_forecast" not in self.config.post_processors:
-            warnings.warn(
-                """
-                post_processors are defined but `accumulate_from_start_of_forecast` is not set."
-                🚧 Accumulations will NOT be accumulated from the beginning of the forecast. 🚧
-                """
-            )
-
         result = []
         for processor in self.config.pre_processors:
             result.append(create_pre_processor(self, processor))


### PR DESCRIPTION
## Description
To accumulate accumulation fields from the start of the forecast, the user now has to explicitly add the `accumulate_from_start_of_forecast` post_processor to their config.

We keep showing a warning in the log just in case (printed at the end of the run just to make sure people see it). After some time we can remove this warning, or instead of a warning we show some kind of summary of the forecast with this information. 

## What issue or task does this change relate to?
closes #131

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
