### PR TITLE
fix: Use data frequency to be consistent with training

### DIFF
--- a/src/anemoi/inference/checkpoint.py
+++ b/src/anemoi/inference/checkpoint.py
@@ -25,6 +25,7 @@ from typing import Union
 import earthkit.data as ekd
 from anemoi.utils.checkpoints import load_metadata
 from earthkit.data.utils.dates import to_datetime
+from anemoi.utils.dates import frequency_to_timedelta as to_timedelta
 
 from anemoi.inference.forcings import Forcings
 from anemoi.inference.types import DataRequest
@@ -161,6 +162,16 @@ class Checkpoint:
     def target_explicit_times(self) -> Any:
         """Get the target explicit times."""
         return self._metadata.target_explicit_times
+    
+    @property
+    def interpolation_window(self) -> Any:
+        """Get the interpolation window."""
+        return to_timedelta(self.data_frequency) * (self.input_explicit_times[1] - self.input_explicit_times[0])
+    
+    @property
+    def data_frequency(self) -> Any:
+        """Get the data frequency."""
+        return self._metadata._config_data.frequency
 
     @property
     def precision(self) -> Any:


### PR DESCRIPTION
## Description
<!-- What issue or task does this change relate to? -->
As per https://github.com/ecmwf/anemoi-inference/issues/264 the inference stage was implemented using `timestep` while the training stage does not use this argument at all.
## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->

## What issue or task does this change relate to?
<!-- link to Issue Number -->
https://github.com/ecmwf/anemoi-inference/issues/26
##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->
This does not fully address As per https://github.com/ecmwf/anemoi-inference/issues/26 as it still operates on a fixed interpolation window.
***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
