### PR TITLE
feat: Add logging control to mars

### DIFF
--- a/src/anemoi/inference/inputs/mars.py
+++ b/src/anemoi/inference/inputs/mars.py
@@ -138,6 +138,7 @@ def retrieve(
     grid: Optional[Union[str, List[float]]],
     area: Optional[List[float]],
     patch: Optional[Any] = None,
+    log: bool = True,
     **kwargs: Any,
 ) -> Any:
     """Retrieve data from MARS.
@@ -152,6 +153,8 @@ def retrieve(
         The area for the retrieval.
     patch : Optional[Any], optional
         Optional patch for the request, by default None.
+    log : bool, optional
+        Whether to log the requests, by default True.
     **kwargs : Any
         Additional keyword arguments.
 
@@ -192,7 +195,7 @@ def retrieve(
 
         LOG.debug("%s", _(r))
 
-        result += ekd.from_source("mars", r)
+        result += ekd.from_source("mars", r, log="default" if log else None)
 
     return result
 
@@ -209,6 +212,7 @@ class MarsInput(GribInput):
         *,
         namer: Optional[Any] = None,
         patches: Optional[List[Tuple[Dict[str, Any], Dict[str, Any]]]] = None,
+        log: bool = True,
         **kwargs: Any,
     ) -> None:
         """Initialize the MarsInput.
@@ -221,6 +225,8 @@ class MarsInput(GribInput):
             Optional namer for the input.
         patches : Optional[List[Tuple[Dict[str, Any], Dict[str, Any]]]]
             Optional list of patches for the input.
+        log : bool
+            Whether to log the requests to MARS, by default True.
         **kwargs : Any
             Additional keyword to pass to the request to MARS.
         """
@@ -229,6 +235,7 @@ class MarsInput(GribInput):
         self.variables = self.checkpoint.variables_from_input(include_forcings=False)
         self.kwargs = kwargs
         self.patches = patches or []
+        self.log = log
 
     def create_input_state(self, *, date: Optional[Date]) -> State:
         """Create the input state for the given date.
@@ -289,6 +296,7 @@ class MarsInput(GribInput):
         return retrieve(
             requests,
             patch=self.patch,
+            log=self.log,
             **kwargs,
         )
 


### PR DESCRIPTION
## Description
Allow for `mars` logging to be turned off.

## Examples
### Yaml
```yaml
input:
 mars:
  log: False
```
### Python
```python
from anemoi.inference.inputs.mars import MarsInput
MarsInput(log = False)
```


By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
