### PR TITLE
fix: Tensor not detached in debug mode

### DIFF
--- a/src/anemoi/inference/runner.py
+++ b/src/anemoi/inference/runner.py
@@ -642,11 +642,15 @@ class Runner(Context):
                     new_state["fields"][self.checkpoint.output_tensor_index_to_variable[i]] = output[:, i]
 
             if (s == 0 and self.verbosity > 0) or self.verbosity > 1:
-                self._print_output_tensor("Output tensor", output)
+                self._print_output_tensor("Output tensor", output.cpu().numpy())
 
             if self.trace:
                 self.trace.write_output_tensor(
-                    date, s, output, self.checkpoint.output_tensor_index_to_variable, self.checkpoint.timestep
+                    date,
+                    s,
+                    output.cpu().numpy(),
+                    self.checkpoint.output_tensor_index_to_variable,
+                    self.checkpoint.timestep,
                 )
 
             yield new_state


### PR DESCRIPTION
## Description
Output tensor was not detached when printing it or writing it to a trace file, side effect of #263. 


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
