### PR TITLE
fix(grib): Ocean grib encoding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ classifiers = [
 
 dynamic = [ "version" ]
 dependencies = [
-  "anemoi-transform>=0.1.4",
+  "anemoi-transform>0.1.13",
   "anemoi-utils[text,provenance]>=0.4.26",
   "aniso8601",
   "anytree",

--- a/src/anemoi/inference/grib/encoding.py
+++ b/src/anemoi/inference/grib/encoding.py
@@ -166,7 +166,7 @@ def encode_time_processing(
                 "Try `write_initial_state: False`"
             )
     else:
-        # backwards compatibility or if period is missing from the metadata
+        # backwards compatibility with old transform or if period is missing from the metadata
         start = previous_step
         warnings.warn(
             f"{variable.name} {variable.time_processing} does not have a period set, using previous_step as start={_step_in_hours(start)}."

--- a/src/anemoi/inference/outputs/grib.py
+++ b/src/anemoi/inference/outputs/grib.py
@@ -72,7 +72,6 @@ class HindcastOutput:
         for k in ("date", "hdate", "eps", "productDefinitionTemplateNumber"):
             keys.pop(k, None)
 
-        keys["edition"] = 1
         keys["localDefinitionNumber"] = 30
         keys["dataDate"] = int(to_datetime(date).strftime("%Y%m%d"))
         keys["referenceDate"] = int(to_datetime(date).replace(year=self.reference_year).strftime("%Y%m%d"))

--- a/src/anemoi/inference/outputs/gribfile.py
+++ b/src/anemoi/inference/outputs/gribfile.py
@@ -74,6 +74,11 @@ def _is_valid(mars: Dict[str, Any], keys: Dict[str, Any]) -> bool:
         LOG.warning("`hdate` is missing from mars namespace")
         return False
 
+    if "startStep" in keys and "endStep" in keys and keys.get("stepType") != "accum":
+        if mars.get("step") != f"{keys['startStep']}-{keys['endStep']}":
+            LOG.warning("`step` is missing a range in mars namespace.")
+            return False
+
     return True
 
 

--- a/src/anemoi/inference/outputs/gribfile.py
+++ b/src/anemoi/inference/outputs/gribfile.py
@@ -51,8 +51,8 @@ MARS_MAYBE_MISSING_KEYS = (
 )
 
 
-def _is_valid(mars: Dict[str, Any], keys: Dict[str, Any]) -> bool:
-    """Check if the mars dictionary contains valid keys.
+def _fix(mars: Dict[str, Any], keys: Dict[str, Any]) -> None:
+    """Check if the mars dictionary contains valid keys and fix it.
 
     Parameters
     ----------
@@ -60,26 +60,21 @@ def _is_valid(mars: Dict[str, Any], keys: Dict[str, Any]) -> bool:
         The mars dictionary.
     keys : Dict[str, Any]
         The keys dictionary.
-
-    Returns
-    -------
-    bool
-        True if valid, False otherwise.
     """
     if "number" in keys and "number" not in mars:
-        LOG.warning("`number` is missing from mars namespace")
-        return False
+        LOG.debug(f"`number` is missing from mars namespace, setting it to {keys['number']}")
+        mars["number"] = keys["number"]
 
     if "referenceDate" in keys and "hdate" not in mars:
-        LOG.warning("`hdate` is missing from mars namespace")
-        return False
+        LOG.debug(f"`hdate` is missing from mars namespace, setting it to {keys['referenceDate']}")
+        mars["hdate"] = keys["referenceDate"]
 
     if "startStep" in keys and "endStep" in keys and keys.get("stepType") != "accum":
         if mars.get("step") != f"{keys['startStep']}-{keys['endStep']}":
-            LOG.warning("`step` is missing a range in mars namespace.")
-            return False
-
-    return True
+            LOG.debug(
+                f"{keys.get('stepType')} `step={mars.get('step')}` is not a range,  setting it to {keys['startStep']}-{keys['endStep']}."
+            )
+            mars["step"] = f"{keys['startStep']}-{keys['endStep']}"
 
 
 class ArchiveCollector:
@@ -261,24 +256,8 @@ class GribIoOutput(BaseGribOutput):
 
         handle, path = written
 
-        while True:
-            if self._namespace_bug_fix:
-                import eccodes
-                from earthkit.data.readers.grib.codes import GribCodesHandle
-
-                handle = GribCodesHandle(eccodes.codes_clone(handle._handle), None, None)
-
-            mars = {k: v for k, v in handle.items("mars")}
-
-            if _is_valid(mars, keys):
-                break
-
-            if self._namespace_bug_fix:
-                raise ValueError("Namespace bug: %s" % mars)
-
-            # Try again with the namespace bug
-            LOG.warning("Namespace bug detected, trying again")
-            self._namespace_bug_fix = True
+        mars = {k: v for k, v in handle.items("mars")}
+        _fix(mars, keys)
 
         if self.check_encoding:
             check_encoding(handle, keys)


### PR DESCRIPTION
## Description
A three-for-one grib special:

- Remove the hardcoded edition=1 for hindcasts so that we can do hindcasts with grib2-only variables, like those in the ocean. The edition comes from the template, so grib1 in will still do grib1 out. 
- Perform time encoding with the period information in the variable metadata, instead of the model's step size. This is to support fields that have different periods than the model step (like ocean averages).
- When the `accumulate_from_start_of_forecast` processor was enabled, we didn't properly set `startStep=0`, it was doing `startStep=previous_step`.

Draft for now (tests will be failing) because it needs a new release of transform after merging this:
https://github.com/ecmwf/anemoi-transform/pull/132

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
