### PR TITLE
feat: Option to pass extra kwargs to `predict_step`

### DIFF
--- a/src/anemoi/inference/config/run.py
+++ b/src/anemoi/inference/config/run.py
@@ -88,6 +88,9 @@ class RunConfiguration(Configuration):
     written.
     """
 
+    predict_kwargs: Dict[str, Any] = Field(default_factory=dict)
+    """Extra keyword arguments to pass to the model's predict_step method. Will ignore kwargs that are already passed by the runner."""
+
     typed_variables: Dict[str, Dict] = Field(default_factory=dict)
     """A list of typed variables to support the encoding of outputs."""
 


### PR DESCRIPTION
## Description
Adds a `predict_kwargs` entry to the config where the user can pass extra kwargs to the model's predict_step.

Internal kwargs already passed by the runner will be ignored.

This functionality will be used for the diffusion model, which has a bunch of tweakable kwargs in the predict_step signature:
https://github.com/ecmwf/anemoi-core/pull/401/files#diff-394e57d4fb30199c3dbe0386477c0450c0517a114b5ea3119e7a325f2e1a8fb0R322-R343

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
