### PR TITLE
feat(post-processors): extraction post-processors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ optional-dependencies.docs = [
 optional-dependencies.huggingface = [ "huggingface-hub" ]
 optional-dependencies.plugin = [ "ai-models>=0.7", "tqdm" ]
 
-optional-dependencies.tests = [ "anemoi-datasets[all]", "anemoi-inference[all]", "hypothesis", "pytest" ]
+optional-dependencies.tests = [ "anemoi-datasets[all]", "anemoi-inference[all]", "hypothesis", "pytest", "pytest-mock" ]
 
 optional-dependencies.zarr = [ "zarr" ]
 

--- a/src/anemoi/inference/outputs/masked.py
+++ b/src/anemoi/inference/outputs/masked.py
@@ -8,6 +8,7 @@
 # nor does it submit to any jurisdiction.
 
 import logging
+import warnings
 from typing import Any
 from typing import List
 from typing import Optional
@@ -54,6 +55,12 @@ class MaskedOutput(ForwardOutput):
         output_frequency: Optional[int] = None,
         write_initial_state: Optional[bool] = None,
     ) -> None:
+
+        warnings.warn(
+            f"The {self.__class__.__name__} is deprecated and will be removed in a future release. "
+            "Use extraction post-processors instead.",
+            DeprecationWarning,
+        )
         super().__init__(
             context,
             output,

--- a/src/anemoi/inference/outputs/printer.py
+++ b/src/anemoi/inference/outputs/printer.py
@@ -134,7 +134,7 @@ class PrinterOutput(Output):
             Additional keyword arguments.
         """
 
-        super().__init__(context, post_processors)
+        super().__init__(context, variables=variables, post_processors=post_processors)
         self.print = print
         self.variables = variables
 

--- a/src/anemoi/inference/post_processors/extract.py
+++ b/src/anemoi/inference/post_processors/extract.py
@@ -44,6 +44,7 @@ class ExtractBase(Processor):
             The updated state with extracted fields.
         """
         state = state.copy()
+        state["fields"] = state["fields"].copy()
 
         state["latitudes"] = state["latitudes"][self.indexer]
         state["longitudes"] = state["longitudes"][self.indexer]

--- a/src/anemoi/inference/post_processors/extract.py
+++ b/src/anemoi/inference/post_processors/extract.py
@@ -9,6 +9,7 @@
 
 
 import logging
+from pathlib import Path
 
 import numpy as np
 
@@ -26,6 +27,7 @@ LOG = logging.getLogger(__name__)
 class ExtractBase(Processor):
     """Base class for processors that extract data from the state."""
 
+    # this needs to be set in subclasses
     indexer: BoolArray | slice
 
     def process(self, state: State) -> State:
@@ -70,7 +72,7 @@ class ExtractMask(ExtractBase):
 
         self._maskname = mask
 
-        if mask.endswith(".npy"):
+        if Path(mask).is_file():
             mask = np.load(mask)
         else:
             mask = context.checkpoint.load_supporting_array(mask)

--- a/src/anemoi/inference/post_processors/extract.py
+++ b/src/anemoi/inference/post_processors/extract.py
@@ -1,0 +1,122 @@
+# (C) Copyright 2024-2025 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+
+import logging
+
+import numpy as np
+
+from anemoi.inference.context import Context
+from anemoi.inference.decorators import main_argument
+from anemoi.inference.types import BoolArray
+from anemoi.inference.types import State
+
+from ..processor import Processor
+from . import post_processor_registry
+
+LOG = logging.getLogger(__name__)
+
+
+class ExtractBase(Processor):
+    """Base class for processors that extract data from the state."""
+
+    indexer: BoolArray | slice
+
+    def process(self, state: State) -> State:
+        """Process the state to extract a subset of points based on the indexer.
+
+        Parameters
+        ----------
+        state : State
+            The state containing fields to be extracted.
+
+        Returns
+        -------
+        State
+            The updated state with extracted fields.
+        """
+        state = state.copy()
+
+        state["latitudes"] = state["latitudes"][self.indexer]
+        state["longitudes"] = state["longitudes"][self.indexer]
+        for field in state["fields"]:
+            state["fields"][field] = state["fields"][field][self.indexer]
+
+        return state
+
+
+@post_processor_registry.register("extract_mask")
+@main_argument("mask")
+class ExtractMask(ExtractBase):
+    """Extract a subset of points from the state based on a boolean mask.
+
+    Parameters
+    ----------
+    context : Any
+        The context in which the processor is running.
+    mask : str
+        Either a path to a `.npy` file containing the boolean mask or
+        the name of a supporting array found in the checkpoint.
+    """
+
+    def __init__(self, context: Context, mask: str) -> None:
+        super().__init__(context)
+
+        self._maskname = mask
+
+        if mask.endswith(".npy"):
+            mask = np.load(mask)
+        else:
+            mask = context.checkpoint.load_supporting_array(mask)
+
+        if not isinstance(mask, np.ndarray) or mask.dtype != bool:
+            raise ValueError(
+                "Expected the mask to be a boolean numpy array. " f"Got {type(mask)} with dtype {mask.dtype}."
+            )
+
+        self.indexer = mask
+        self.npoints = np.sum(mask)
+
+    def __repr__(self) -> str:
+        """Return a string representation of the ExtractMask object.
+
+        Returns
+        -------
+        str
+            String representation of the object.
+        """
+        return f"ExtractMask({self._maskname}, points={self.npoints}/{self.indexer.size})"
+
+
+@post_processor_registry.register("extract_slice")
+class ExtractSlice(ExtractBase):
+    """Extract a subset of points from the state based on a slice.
+
+    Parameters
+    ----------
+    context : Context
+        The context in which the processor is running.
+    slice_args : int
+        Arguments to create a slice object. This can be a single integer or
+        a tuple of integers representing the start, stop, and step of the slice.
+    """
+
+    def __init__(self, context: Context, *slice_args: int) -> None:
+        super().__init__(context)
+        self.indexer = slice(*slice_args)
+
+    def __repr__(self) -> str:
+        """Return a string representation of the ExtractSlice object.
+
+        Returns
+        -------
+        str
+            String representation of the object.
+        """
+        return f"ExtractSlice({self.indexer})"

--- a/src/anemoi/inference/post_processors/extract.py
+++ b/src/anemoi/inference/post_processors/extract.py
@@ -10,6 +10,7 @@
 
 import logging
 from pathlib import Path
+from typing import Union
 
 import numpy as np
 
@@ -28,7 +29,7 @@ class ExtractBase(Processor):
     """Base class for processors that extract data from the state."""
 
     # this needs to be set in subclasses
-    indexer: BoolArray | slice
+    indexer: Union[BoolArray, slice]
 
     def process(self, state: State) -> State:
         """Process the state to extract a subset of points based on the indexer.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,10 @@
 # nor does it submit to any jurisdiction.
 
 
+from datetime import datetime
+from datetime import timedelta
+
+import numpy as np
 import pytest
 
 pytest_plugins = "anemoi.utils.testing"
@@ -35,3 +39,31 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
         for item in items:
             if item.get_closest_marker("longtests"):
                 item.add_marker(skip_marker)
+
+
+STATE_NPOINTS = 50
+
+
+@pytest.fixture
+def state():
+    """Fixture to create a mock state for testing."""
+
+    return {
+        "latitudes": np.random.uniform(-90, 90, size=STATE_NPOINTS),
+        "longitudes": np.random.uniform(-180, 180, size=STATE_NPOINTS),
+        "fields": {
+            "2t": np.random.uniform(250, 310, size=STATE_NPOINTS),
+            "z_850": np.random.uniform(500, 1500, size=STATE_NPOINTS),
+        },
+        "date": datetime(2020, 1, 1, 0, 0),
+        "step": timedelta(hours=6),
+    }
+
+
+@pytest.fixture
+def extract_mask_npy(tmp_path):
+    """Fixture to create a mock mask in .npy format."""
+    mask = np.random.choice([True, False], size=STATE_NPOINTS)
+    mask_path = tmp_path / "mask.npy"
+    np.save(mask_path, mask)
+    return str(mask_path)

--- a/tests/unit/test_post_processors.py
+++ b/tests/unit/test_post_processors.py
@@ -1,0 +1,86 @@
+from typing import cast
+
+import numpy as np
+from pytest_mock import MockerFixture
+
+from anemoi.inference.context import Context
+from anemoi.inference.post_processors.extract import ExtractMask
+from anemoi.inference.post_processors.extract import ExtractSlice
+from anemoi.inference.types import State
+
+
+def test_extract_mask_supporting_array(
+    mocker: MockerFixture,
+    state: State,
+    extract_mask_npy: str,
+):
+
+    # mock the context to return the mask when load_supporting_array is called
+    mask = np.load(extract_mask_npy)
+    context = cast(Context, mocker.MagicMock())
+    context.checkpoint.load_supporting_array.return_value = mask
+    processor = ExtractMask(context=context, mask="some_supporting_array")
+
+    # check that load_supporting_array was called with the correct name
+    context.checkpoint.load_supporting_array.assert_called_once_with("some_supporting_array")
+
+    # check that the indexer is set correctly
+    np.testing.assert_equal(processor.indexer, mask)
+
+    # check that extraction works as expected
+    new_state = processor.process(state)
+    assert new_state["latitudes"].shape[0] == mask.sum()
+    for field in new_state["fields"]:
+        assert new_state["fields"][field].shape[0] == mask.sum()
+        assert np.all(new_state["fields"][field] == state["fields"][field][mask])
+
+
+def test_extract_mask_npy(
+    mocker: MockerFixture,
+    state: State,
+    extract_mask_npy: str,
+):
+    mask = np.load(extract_mask_npy)
+
+    # mock the context just because ExtractMask requires it
+    context: Context = cast(Context, mocker.MagicMock())
+    processor = ExtractMask(context, extract_mask_npy)
+
+    # check that nothing was done with the context
+    context.checkpoint.load_supporting_array.assert_not_called()
+
+    # check that the indexer is set correctly
+    np.testing.assert_equal(processor.indexer, mask)
+
+    # check that extraction works as expected
+    new_state = processor.process(state)
+    assert new_state["latitudes"].shape[0] == mask.sum()
+    for field in new_state["fields"]:
+        assert new_state["fields"][field].shape[0] == mask.sum()
+        assert np.all(new_state["fields"][field] == state["fields"][field][mask])
+
+
+def test_extract_slice(
+    mocker: MockerFixture,
+    state: State,
+):
+
+    slice_args = (0, 25)
+    extract_slice = slice(*slice_args)
+
+    # mock the context just because ExtractSlice requires it
+    context = cast(Context, mocker.MagicMock())
+    processor = ExtractSlice(context, *slice_args)
+
+    # check that nothing was done with the context
+    context.checkpoint.load_supporting_array.assert_not_called()
+
+    # check that the indexer is set correctly
+    np.testing.assert_equal(processor.indexer, extract_slice)
+
+    # check that extraction works as expected
+    new_state = processor.process(state)
+    assert new_state["latitudes"].shape[0] == 25
+    for field in new_state["fields"]:
+        assert new_state["fields"][field].shape[0] == 25
+        assert np.all(new_state["fields"][field] == state["fields"][field][extract_slice])

--- a/tests/unit/test_post_processors.py
+++ b/tests/unit/test_post_processors.py
@@ -1,3 +1,11 @@
+# (C) Copyright 2024 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
 from typing import cast
 
 import numpy as np


### PR DESCRIPTION
## Description 

This PR adds two new post-processors `extract_mask` and `extract_slice` (the extraction logic is shared in a common class), which can be used to extract subsets of points from the state based on boolean masks or slices respectively. Closes #281. 

The post-processors can be used as follows:

```yaml
output:
  printer:
    post_processors:
      - extract_slice: [0, 189700]
```

or 

```yaml
output:
  printer:
    post_processors:
      - extract_mask: mask/in/supporting_arrays or /path/to/mask.npy
```

---

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
