### PR TITLE
feat(post-processors): add `assign_mask` post-processor

### DIFF
--- a/src/anemoi/inference/outputs/assign_mask.py
+++ b/src/anemoi/inference/outputs/assign_mask.py
@@ -8,6 +8,7 @@
 # nor does it submit to any jurisdiction.
 
 import logging
+import warnings
 from typing import List
 from typing import Optional
 
@@ -66,6 +67,11 @@ class AssignMask(ForwardOutput):
     ) -> None:
         super().__init__(
             context, output, post_processors, output_frequency=output_frequency, write_initial_state=write_initial_state
+        )
+        warnings.warn(
+            "The AssignMask output is deprecated and will be removed in a future release. "
+            "Use the `assign_mask` post-processor instead.",
+            DeprecationWarning,
         )
 
         if mask not in self.checkpoint.supporting_arrays:

--- a/src/anemoi/inference/post_processors/assign.py
+++ b/src/anemoi/inference/post_processors/assign.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2024-2025 Anemoi contributors.
+# (C) Copyright 2025- Anemoi contributors.
 #
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.

--- a/src/anemoi/inference/post_processors/assign.py
+++ b/src/anemoi/inference/post_processors/assign.py
@@ -1,0 +1,103 @@
+# (C) Copyright 2024-2025 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+from pathlib import Path
+
+import numpy as np
+
+from anemoi.inference.context import Context
+from anemoi.inference.decorators import main_argument
+from anemoi.inference.types import State
+
+from ..processor import Processor
+from . import post_processor_registry
+
+
+@post_processor_registry.register("assign_mask")
+@main_argument("mask")
+class AssignMask(Processor):
+    """Assign a mask to the state.
+
+    This processor assigns the state to a larger array using a mask to
+    determine the region of assignment. The mask can be provided as a
+    boolean numpy array or as a path to a file containing the mask.
+    This processor can be seen as the opposite of "extract_mask".
+    Instead of extracting a smaller area from a larger one,
+    it assigns a state to a larger area using a mask.
+
+    Parameters
+    ----------
+    context : Context
+        The context containing the checkpoint and supporting arrays.
+    mask : str
+        The name of the mask supporting array or a path to a file containing the mask.
+    fill_value : float, optional
+        The value to fill the non-assigned area, by default NaN.
+    """
+
+    def __init__(self, context: Context, mask: str, fill_value: float = float("NaN")) -> None:
+        super().__init__(context)
+
+        self._maskname = mask
+
+        if Path(mask).is_file():
+            mask = np.load(mask)
+        else:
+            mask = context.checkpoint.load_supporting_array(mask)
+
+        if not isinstance(mask, np.ndarray) or mask.dtype != bool:
+            raise ValueError(
+                "Expected the mask to be a boolean numpy array. " f"Got {type(mask)} with dtype {mask.dtype}."
+            )
+
+        self.indexer = mask
+        self.npoints = np.sum(mask)
+        self.fill_value = fill_value
+
+    def process(self, state: State) -> State:
+        """Assign the state to the mask.
+
+        Parameters
+        ----------
+        state : State
+            The state dictionary.
+
+        Returns
+        -------
+        State
+            The masked state dictionary.
+        """
+        state = state.copy()
+        state["fields"] = state["fields"].copy()
+
+        state["latitudes"] = self._assign_mask(state["latitudes"])
+        state["longitudes"] = self._assign_mask(state["longitudes"])
+        for field in state["fields"]:
+            state["fields"][field] = self._assign_mask(state["fields"][field])
+
+        return state
+
+    def _assign_mask(self, array: np.ndarray):
+        """Logic to assign the array to the mask."""
+        shape = array.shape[:-1] + self.indexer.shape
+        res = np.full(shape, self.fill_value, dtype=array.dtype)
+        if array.ndim == 1:
+            res[self.indexer] = array
+        else:
+            res[..., self.indexer] = array
+        return res
+
+    def __repr__(self) -> str:
+        """Return a string representation of the AssignMask object.
+
+        Returns
+        -------
+        str
+            A string representation of the AssignMask object.
+        """
+        return f"AssignMask(mask={self._maskname}, points={self.npoints}/{self.indexer.size}, fill_value={self.fill_value})"

--- a/src/anemoi/inference/post_processors/extract.py
+++ b/src/anemoi/inference/post_processors/extract.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2024-2025 Anemoi contributors.
+# (C) Copyright 2025- Anemoi contributors.
 #
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,6 +64,16 @@ def state():
 def extract_mask_npy(tmp_path):
     """Fixture to create a mock mask in .npy format."""
     mask = np.random.choice([True, False], size=STATE_NPOINTS)
-    mask_path = tmp_path / "mask.npy"
+    mask_path = tmp_path / "extract_mask.npy"
+    np.save(mask_path, mask)
+    return str(mask_path)
+
+
+@pytest.fixture
+def assign_mask_npy(tmp_path):
+    """Fixture to create a mock mask in .npy format."""
+    mask = np.zeros(STATE_NPOINTS + 10, dtype=bool)
+    mask[:STATE_NPOINTS] = True
+    mask_path = tmp_path / "assign_mask.npy"
     np.save(mask_path, mask)
     return str(mask_path)

--- a/tests/unit/test_post_processors.py
+++ b/tests/unit/test_post_processors.py
@@ -12,9 +12,63 @@ import numpy as np
 from pytest_mock import MockerFixture
 
 from anemoi.inference.context import Context
+from anemoi.inference.post_processors.assign import AssignMask
 from anemoi.inference.post_processors.extract import ExtractMask
 from anemoi.inference.post_processors.extract import ExtractSlice
 from anemoi.inference.types import State
+
+
+def test_assign_mask_supporting_array(
+    mocker: MockerFixture,
+    state: State,
+    assign_mask_npy: str,
+):
+
+    # mock the context to return the mask when load_supporting_array is called
+    mask = np.load(assign_mask_npy)
+    context = cast(Context, mocker.MagicMock())
+    context.checkpoint.load_supporting_array.return_value = mask
+    processor = AssignMask(context=context, mask="some_supporting_array")
+
+    # check that load_supporting_array was called with the correct name
+    context.checkpoint.load_supporting_array.assert_called_once_with("some_supporting_array")
+
+    # check that the indexer is set correctly
+    np.testing.assert_equal(processor.indexer, mask)
+
+    # check that assignment works as expected
+    new_state = processor.process(state)
+    assert new_state["latitudes"].shape[0] == mask.shape[0]
+    assert np.isnan(new_state["latitudes"]).sum() == (~mask).sum()
+    for field in new_state["fields"]:
+        assert new_state["fields"][field].shape[0] == mask.shape[0]
+        assert np.isnan(new_state["fields"][field]).sum() == (~mask).sum()
+
+
+def test_assign_mask_npy(
+    mocker: MockerFixture,
+    state: State,
+    assign_mask_npy: str,
+):
+    mask = np.load(assign_mask_npy)
+
+    # mock the context just because AssignMask requires it
+    context: Context = cast(Context, mocker.MagicMock())
+    processor = AssignMask(context, assign_mask_npy)
+
+    # check that nothing was done with the context
+    context.checkpoint.load_supporting_array.assert_not_called()
+
+    # check that the indexer is set correctly
+    np.testing.assert_equal(processor.indexer, mask)
+
+    # check that assignment works as expected
+    new_state = processor.process(state)
+    assert new_state["latitudes"].shape[0] == mask.shape[0]
+    assert np.isnan(new_state["latitudes"]).sum() == (~mask).sum()
+    for field in new_state["fields"]:
+        assert new_state["fields"][field].shape[0] == mask.shape[0]
+        assert np.isnan(new_state["fields"][field]).sum() == (~mask).sum()
 
 
 def test_extract_mask_supporting_array(


### PR DESCRIPTION
## Description
This PR adds a new `assign_mask` post-processor that can be used to assign the arrays in the current state object to arrays of a larger size using a boolean array mask. It can be seen as the inverse of `extract_mask` introduced in #285. 

The corresponding output type is now deprecated and will be removed in a future release.

- [x] added the new post-processor class
- [x] tested locally on GRIB output (as mentioned in https://github.com/ecmwf/anemoi-inference/pull/285#issuecomment-3132260667) 
- [x] added unit tests

---

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
