### PR TITLE
feat(outputs): Extend tee to enable postprocessors

### DIFF
--- a/src/anemoi/inference/output.py
+++ b/src/anemoi/inference/output.py
@@ -244,7 +244,7 @@ class ForwardOutput(Output):
     def __init__(
         self,
         context: "Context",
-        output: dict,
+        output: dict | None,
         variables: list[str] | None = None,
         post_processors: list[ProcessorConfig] | None = None,
         output_frequency: int | None = None,

--- a/src/anemoi/inference/outputs/tee.py
+++ b/src/anemoi/inference/outputs/tee.py
@@ -31,9 +31,6 @@ class TeeOutput(ForwardOutput):
         context: Context,
         *args: Any,
         outputs: list[Configuration],
-        variables: list[str] | None = None,
-        output_frequency: int | None = None,
-        write_initial_state: bool | None = None,
         **kwargs: Any,
     ):
         """Initialize the TeeOutput.
@@ -46,20 +43,13 @@ class TeeOutput(ForwardOutput):
             Additional positional arguments.
         outputs : list or tuple, optional
             List of outputs to be created.
-        output_frequency : int, optional
-            Frequency of output.
-        write_initial_state : bool, optional
-            Flag to write the initial state.
         **kwargs : Any
             Additional keyword arguments.
         """
         super().__init__(
             context,
             None,
-            variables=variables,
-            post_processors=None,
-            output_frequency=output_frequency,
-            write_initial_state=write_initial_state,
+            **kwargs,
         )
 
         if outputs is None:
@@ -79,6 +69,7 @@ class TeeOutput(ForwardOutput):
             The state dictionary.
         """
         state.setdefault("step", datetime.timedelta(0))
+        state = self.post_process(state)
         for output in self.outputs:
             output.write_initial_state(state)
 
@@ -90,6 +81,7 @@ class TeeOutput(ForwardOutput):
         state : State
             The state dictionary.
         """
+        state = self.post_process(state)
         for output in self.outputs:
             output.write_state(state)
 


### PR DESCRIPTION
## Description
Extend `tee` to allow for nested postprocessors.

## What problem does this change solve?

Allows for complex configs with branching postprocessor.
```yaml
output:
  tee:
    outputs:
      - tee:
          post_processors:
          - extract_mask: 'lam_0/cutout_mask'
          outputs:
          - plot:
              path: outputs/plots/lam/
              variables:
              - 2t
              - msl
          - printer
          - grib: 
              path: 'output.grib'
      - tee:
          outputs:
          - plot:
              path: outputs/plots/global/
              variables:
              - 2t
              - msl
```

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
