### PR TITLE
build(pytest): configure pytest to remove all tmpdirs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,8 @@ markers = [
   "skip_on_hpc: mark a test that should not be run on HPC",
 ]
 testpaths = "tests"
+tmp_path_retention_policy = "none"
+tmp_path_retention_count = 0
 
 [tool.mypy]
 exclude = [ "docs/" ]


### PR DESCRIPTION
## Description
Disable tmpdir retention in pytest. By default, pytest keeps the last 3 tmpdirs when using the tmp_path fixture.

## What problem does this change solve?
We won't leave tmpdirs on runners when running pytest in the ci


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
