### PR TITLE
test: remove longtests pytest cli option

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,30 +17,6 @@ import pytest
 pytest_plugins = "anemoi.utils.testing"
 
 
-def pytest_addoption(parser: pytest.Parser) -> None:
-    parser.addoption(
-        "--longtests",
-        action="store_true",
-        dest="longtests",
-        default=False,
-        help="enable tests marked as longtests",
-    )
-
-
-def pytest_configure(config: pytest.Config) -> None:
-    """Register the 'longtests' marker to avoid warnings."""
-    config.addinivalue_line("markers", "longtests: mark tests as long-running")
-
-
-def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
-    """Automatically skip @pytest.mark.longtests tests unless --longtests is used."""
-    if not config.getoption("--longtests"):
-        skip_marker = pytest.mark.skip(reason="Skipping long test, use --longtests to enable")
-        for item in items:
-            if item.get_closest_marker("longtests"):
-                item.add_marker(skip_marker)
-
-
 STATE_NPOINTS = 50
 
 


### PR DESCRIPTION
## Description
This PR removes --longtests cli option for pytest.

## What problem does this change solve?
Make markers and cli for slow tests consistent across the anemoi packages.

## What issue or task does this change relate to?
https://github.com/ecmwf/anemoi-core/issues/257


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
