### PR TITLE
fix: wrong grid simplification

### DIFF
--- a/src/anemoi/inference/grib/templates/manager.py
+++ b/src/anemoi/inference/grib/templates/manager.py
@@ -155,7 +155,7 @@ class TemplateManager:
 
         if isinstance(grid, (tuple, list)) and len(grid) == 2:
             if grid[0] == grid[1]:
-                return grid[0]
+                return f"{grid[0]}/{grid[1]}"
             return f"{grid[0]}x{grid[1]}"
 
         return grid


### PR DESCRIPTION
## Description
The grid in the template was being simplified incorrectly, according to MIR, proper latlon grid of the same resolution should be two elements.

## What problem does this change solve?
Changes the grid simplification for the template manager.

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)