### PR TITLE
fix(grib output): Skip `timespan` in output keys

### DIFF
--- a/src/anemoi/inference/grib/encoding.py
+++ b/src/anemoi/inference/grib/encoding.py
@@ -305,6 +305,7 @@ def grib_keys(
             "date",
             "hdate",
             "time",
+            "timespan",
             "valid_datetime",
             "variable",
         ):


### PR DESCRIPTION
## Description
Skip the `timespan` key in the grib output keys, that was sometimes carried over from the metadata. 

If "illegal" keys keep finding their way into the grib output we could consider going to an inclusion list instead of exclusion, or we make it part of the config. But for now just adding keys to this list is a quick and easy fix.

closes #311

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
