### PR TITLE
feat(inspect): JSON output

### DIFF
--- a/src/anemoi/inference/metadata.py
+++ b/src/anemoi/inference/metadata.py
@@ -1117,7 +1117,7 @@ class Metadata(PatchMixin, LegacyMixin):
         ###########################################################################
 
         full_paths = self._get_datasets_full_paths()
-        print(full_paths)
+        LOG.info(full_paths)
         n = 0
 
         def _fix(x: Any) -> Any:
@@ -1128,7 +1128,7 @@ class Metadata(PatchMixin, LegacyMixin):
 
             if isinstance(x, dict):
                 if x.get("action", "").startswith("zarr"):
-                    print(n, x)
+                    LOG.info(n, x)
                     path = full_paths[n]
                     n += 1
                     x["path"] = path


### PR DESCRIPTION
## Description
Option for the `inspect` command to output in pure JSON, like this:

```shell
$ anemoi-inference inspect --json checkpoint.ckpt
```

This can be useful when inspecting the checkpoint programmatically, for example:

```shell
$ anemoi-inference inspect --json checkpoint.ckpt | jq '.diagnostic_variables'
[
  "cp",
  "tp"
]
```

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
