### PR TITLE
fix: Inference with single variable

### DIFF
--- a/src/anemoi/inference/runner.py
+++ b/src/anemoi/inference/runner.py
@@ -646,10 +646,7 @@ class Runner(Context):
                 y_pred = self.predict_step(self.model, input_tensor_torch, fcstep=s, step=step, date=date)
 
             output = torch.squeeze(y_pred, dim=(0, 1))  # shape: (values, variables)
-            if output.ndim == 1:
-                # If there is only one variable, we need to add a dimension
-                output = output.reshape(output.shape[0], 1)  # shape: (values, variables)
-
+            
             # Update state
             with ProfilingLabel("Updating state (CPU)", self.use_profiler):
                 for i in range(output.shape[1]):

--- a/src/anemoi/inference/runner.py
+++ b/src/anemoi/inference/runner.py
@@ -645,7 +645,7 @@ class Runner(Context):
             ):
                 y_pred = self.predict_step(self.model, input_tensor_torch, fcstep=s, step=step, date=date)
 
-            output = torch.squeeze(y_pred)  # shape: (values, variables)
+            output = torch.squeeze(y_pred, dim=(0,1))  # shape: (values, variables)
             if output.ndim == 1:
                 # If there is only one variable, we need to add a dimension
                 output = output.reshape(output.shape[0], 1)  # shape: (values, variables)

--- a/src/anemoi/inference/runner.py
+++ b/src/anemoi/inference/runner.py
@@ -646,6 +646,13 @@ class Runner(Context):
                 y_pred = self.predict_step(self.model, input_tensor_torch, fcstep=s, step=step, date=date)
 
             output = torch.squeeze(y_pred)  # shape: (values, variables)
+            if output.ndim == 1:
+                # If there is only one variable, we need to add a dimension
+                print(f"Predicted tensor shape: {y_pred.shape}")
+                print(f"Output shape: {output.shape}")
+                print(f" Reshape output to 2D tensor")
+                output = output.reshape(output.shape[0], 1)  # shape: (values, variables)
+                print(f"Output shape: {output.shape}")
 
             # Update state
             with ProfilingLabel("Updating state (CPU)", self.use_profiler):

--- a/src/anemoi/inference/runner.py
+++ b/src/anemoi/inference/runner.py
@@ -645,7 +645,7 @@ class Runner(Context):
             ):
                 y_pred = self.predict_step(self.model, input_tensor_torch, fcstep=s, step=step, date=date)
 
-            output = torch.squeeze(y_pred, dim=(0,1))  # shape: (values, variables)
+            output = torch.squeeze(y_pred, dim=(0, 1))  # shape: (values, variables)
             if output.ndim == 1:
                 # If there is only one variable, we need to add a dimension
                 output = output.reshape(output.shape[0], 1)  # shape: (values, variables)

--- a/src/anemoi/inference/runner.py
+++ b/src/anemoi/inference/runner.py
@@ -648,11 +648,7 @@ class Runner(Context):
             output = torch.squeeze(y_pred)  # shape: (values, variables)
             if output.ndim == 1:
                 # If there is only one variable, we need to add a dimension
-                print(f"Predicted tensor shape: {y_pred.shape}")
-                print(f"Output shape: {output.shape}")
-                print(f" Reshape output to 2D tensor")
                 output = output.reshape(output.shape[0], 1)  # shape: (values, variables)
-                print(f"Output shape: {output.shape}")
 
             # Update state
             with ProfilingLabel("Updating state (CPU)", self.use_profiler):

--- a/src/anemoi/inference/runner.py
+++ b/src/anemoi/inference/runner.py
@@ -646,7 +646,7 @@ class Runner(Context):
                 y_pred = self.predict_step(self.model, input_tensor_torch, fcstep=s, step=step, date=date)
 
             output = torch.squeeze(y_pred, dim=(0, 1))  # shape: (values, variables)
-            
+
             # Update state
             with ProfilingLabel("Updating state (CPU)", self.use_profiler):
                 for i in range(output.shape[1]):


### PR DESCRIPTION
## Description
Fix for running inference with single variable output

## What problem does this change solve?
When running anemoi-inference, and only predicting one single variable, the run will fail due to the "output"-variable being squeezed into a 1D array. Anemoi-infernece expect it to be 2D.
The same problem occurs when running the downscaling runner (as noted by user @paulina-t )

## What issue or task does this change relate to?
N/A

##  Additional notes ##
N/A

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
