### PR TITLE
fix: support empty input files

### DIFF
--- a/src/anemoi/inference/inputs/ekd.py
+++ b/src/anemoi/inference/inputs/ekd.py
@@ -223,14 +223,18 @@ class EkdInput(Input):
         """
         fields = self.pre_process(fields)
 
-        if len(fields) == 0:
-            # return dict(date=dates[-1], latitudes=latitudes, longitudes=longitudes, fields=dict())
-            raise ValueError("No input fields provided")
+        # if len(fields) == 0:
+        # return dict(date=dates[-1], latitudes=latitudes, longitudes=longitudes, fields=dict())
+        # raise ValueError("No input fields provided")
 
         dates = sorted([to_datetime(d) for d in dates])
         date_to_index = {d.isoformat(): i for i, d in enumerate(dates)}
 
         state = dict(date=dates[-1], latitudes=latitudes, longitudes=longitudes, fields=dict())
+
+        if len(fields) == 0:
+            LOG.warning("No input fields found for dates %s (%s)", [d.isoformat() for d in dates], self)
+            return state
 
         state_fields = state["fields"]
 

--- a/src/anemoi/inference/inputs/gribfile.py
+++ b/src/anemoi/inference/inputs/gribfile.py
@@ -9,6 +9,7 @@
 
 
 import logging
+import os
 from functools import cached_property
 from typing import Any
 
@@ -98,4 +99,7 @@ class GribFileInput(GribInput):
     @cached_property
     def _fieldlist(self) -> ekd.FieldList:
         """Get the input fieldlist from the GRIB file."""
+        if os.path.getsize(self.path) == 0:
+            LOG.warning(f"GRIB file {self.path} is empty")
+            return ekd.from_source("empty")
         return ekd.from_source("file", self.path)


### PR DESCRIPTION
## Description

Support empty input files (GRIB). This allows scripts to create different inputs for prognostics, forcing and constants even if one of the category is empty.

## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
