### PR TITLE
fix(retrieve): Default input type

### DIFF
--- a/src/anemoi/inference/commands/retrieve.py
+++ b/src/anemoi/inference/commands/retrieve.py
@@ -220,7 +220,7 @@ class RetrieveCmd(Command):
         # This is a alias to pairs of include/exclude
         command_parser.add_argument(
             "--input-type",
-            default="default",
+            default="default-input",
             choices=sorted(Variables.input_types()),
             help="Type of input variables to retrieve.",
         )


### PR DESCRIPTION
## Description
Default value was wrong, for old versions of prepml that don't pass this option. 

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
