### PR TITLE
style: Lazy torch typing

### DIFF
--- a/src/anemoi/inference/lazy.py
+++ b/src/anemoi/inference/lazy.py
@@ -32,7 +32,8 @@ class LazyModule:
 
 # add heavy imports here, then they can be used in the rest of the codebase as regular imports
 # with type checking and autocompletion: `from anemoi.inference.lazy import torch`
+# note: when used in a type hint, use quotes, e.g. "torch.Tensor" instead of torch.Tensor to avoid triggering the import
 if TYPE_CHECKING:
-    import torch as real_torch
-
-torch: "real_torch" = LazyModule("torch")
+    import torch
+else:
+    torch = LazyModule("torch")

--- a/src/anemoi/inference/runner.py
+++ b/src/anemoi/inference/runner.py
@@ -39,8 +39,6 @@ from .profiler import ProfilingRunner
 from .variables import Variables
 
 if TYPE_CHECKING:
-    import torch
-
     from anemoi.inference.runners.parallel import ParallelRunnerMixin
 
 LOG = logging.getLogger(__name__)

--- a/src/anemoi/inference/runners/parallel.py
+++ b/src/anemoi/inference/runners/parallel.py
@@ -12,7 +12,6 @@ import logging
 import os
 import socket
 import subprocess
-from typing import TYPE_CHECKING
 from typing import Any
 from typing import Optional
 
@@ -31,9 +30,6 @@ from . import runner_registry
 from .default import DefaultRunner
 
 LOG = logging.getLogger(__name__)
-
-if TYPE_CHECKING:
-    import torch
 
 
 def create_parallel_runner(config: Configuration, pid: int) -> None:


### PR DESCRIPTION
## Description
Fix pylance complaining about the type hint of the lazy torch object. Import the real one during static type checking, and only create the lazy torch object at runtime. The type checking imports in the consumers of lazy torch can also be removed. 
 
Before:
<img width="791" height="111" alt="image" src="https://github.com/user-attachments/assets/69c1c88d-ceda-45ec-a798-8ebc591e8218" />

After:
<img width="330" height="62" alt="image" src="https://github.com/user-attachments/assets/a25bb9bc-c527-4e91-9b4f-d3ddfeca9b6c" />


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
