### PR TITLE
feat: add inverse option in extract mask

### DIFF
--- a/src/anemoi/inference/post_processors/extract.py
+++ b/src/anemoi/inference/post_processors/extract.py
@@ -91,6 +91,7 @@ class ExtractMask(ExtractBase):
         Default is False.
     inverse : bool, optional
         If True, extract the points where the mask is False instead of True.
+        Default is False.
     """
 
     def __init__(self, context: Context, *, mask: str, as_slice: bool = False, inverse: bool = False) -> None:


### PR DESCRIPTION
Adds the option to take the inverse of a mask in the `extract_mask ` postprocessor. This is used when e.g. extracting the global area from the stretched grid approach, but the cutout input was not used (e.g. inference from `test`).

Cherry-picked a commit by @OpheliaMiralles.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
