### PR TITLE
fix: set more correct typing information

### DIFF
--- a/src/anemoi/inference/runners/__init__.py
+++ b/src/anemoi/inference/runners/__init__.py
@@ -10,12 +10,12 @@ from typing import Any
 
 from anemoi.utils.registry import Registry
 
-from anemoi.inference.config import Configuration
+from anemoi.inference.config.run import RunConfiguration
 
 runner_registry = Registry(__name__)
 
 
-def create_runner(config: Configuration, **kwargs: Any) -> Any:
+def create_runner(config: RunConfiguration, **kwargs: Any) -> Any:
     """Create a runner instance based on the given configuration.
 
     Parameters

--- a/src/anemoi/inference/runners/default.py
+++ b/src/anemoi/inference/runners/default.py
@@ -19,7 +19,7 @@ from anemoi.utils.config import DotDict
 from anemoi.utils.dates import frequency_to_timedelta as to_timedelta
 from pydantic import BaseModel
 
-from anemoi.inference.config import Configuration
+from anemoi.inference.config.run import RunConfiguration
 from anemoi.inference.input import Input
 from anemoi.inference.output import Output
 from anemoi.inference.processor import Processor
@@ -50,7 +50,7 @@ class DefaultRunner(Runner):
     This class provides the default implementation for running inference.
     """
 
-    def __init__(self, config: Configuration) -> None:
+    def __init__(self, config: RunConfiguration) -> None:
         """Initialize the DefaultRunner.
 
         Parameters


### PR DESCRIPTION
## Description

Minor corrections of type declarations on runner constructors and factories. Essentially, some instances of Configuration should have been RunConfiguration.

## What problem does this change solve?

Improves readability


By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)

BEGIN_COMMIT_OVERRIDE
style: set more correct typing information (#399)
END_COMMIT_OVERRIDE
