### PR TITLE
fix(multi-dataset): Training dataset metadata

### DIFF
--- a/src/anemoi/inference/metadata.py
+++ b/src/anemoi/inference/metadata.py
@@ -137,6 +137,10 @@ class Metadata(PatchMixin, LegacyMixin):
         """Return the input explicit times from the training configuration."""
         return self._config_training.explicit_times.input
 
+    def _dataloader(self, partition="training"):
+        """Dataloader configuration for the given partition."""
+        return self._config.dataloader[partition]
+
     ###########################################################################
     # Debugging
     ###########################################################################
@@ -825,7 +829,7 @@ class Metadata(PatchMixin, LegacyMixin):
                 for k, v in x.items():
                     _find(v)
 
-        _find(self._config.dataloader.training.dataset)
+        _find(self._dataloader("training").dataset)
         return result
 
     def open_dataset(
@@ -919,7 +923,7 @@ class Metadata(PatchMixin, LegacyMixin):
             return x
 
         if from_dataloader is not None:
-            args, kwargs = [], self._metadata.config.dataloader[from_dataloader]
+            args, kwargs = [], self._dataloader(from_dataloader)
         else:
             args, kwargs = self._dataset.arguments.args, self._dataset.arguments.kwargs
 
@@ -1192,6 +1196,9 @@ class MultiDatasetMetadata(Metadata):
     @property
     def _inference(self) -> DotDict:
         return self._metadata_inference[self.name]
+
+    def _dataloader(self, partition="training"):
+        return self._config.dataloader[partition].datasets[self.name]
 
     #############################################################################
     # Overrides for properties derived from the new `metadata_inference`


### PR DESCRIPTION
## Description
Metadata related to the dataloader, used when running inference from the training dataset, was not updated yet for use with multi-datasets.

Fixes running inference from the training dataset. @radiradev

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
