### PR TITLE
fix: Remove deprecated usage in `mock_model`

### DIFF
--- a/src/anemoi/inference/checkpoint.py
+++ b/src/anemoi/inference/checkpoint.py
@@ -422,16 +422,19 @@ class Checkpoint:
         """
         return self._metadata.variable_categories()
 
-    def select_variables(self, *, include: list[str] | None = None, exclude: list[str] | None = None) -> list[str]:
+    def select_variables(
+        self, *, include: list[str] | None = None, exclude: list[str] | None = None, has_mars_requests: bool = True
+    ) -> list[str]:
         """Get variables from input.
 
         Parameters
         ----------
         include : Optional[List[str]]
             Categories to include.
-
         exclude : Optional[List[str]]
             Categories to exclude.
+        has_mars_requests: bool
+            If True, only include variables that have MARS requests.
 
         Returns
         -------
@@ -439,7 +442,7 @@ class Checkpoint:
             The selected variables.
 
         """
-        return self._metadata.select_variables(include=include, exclude=exclude)
+        return self._metadata.select_variables(include=include, exclude=exclude, has_mars_requests=has_mars_requests)
 
     def select_variables_and_masks(
         self, *, include: list[str] | None = None, exclude: list[str] | None = None

--- a/src/anemoi/inference/testing/mock_model.py
+++ b/src/anemoi/inference/testing/mock_model.py
@@ -44,8 +44,8 @@ class MockModelBase(torch.nn.Module):
 
         self.lagged = checkpoint.lagged
         self.typed_variables = checkpoint.typed_variables
-        self.prognostic_variables = checkpoint.prognostic_variables
-        self.diagnostic_variables = checkpoint.diagnostic_variables
+        self.prognostic_variables = checkpoint.select_variables(include=["prognostic"], has_mars_requests=False)
+        self.diagnostic_variables = checkpoint.select_variables(include=["diagnostic"], has_mars_requests=False)
         self.timestep = checkpoint.timestep
 
         self.first = True


### PR DESCRIPTION
## Description
`mock_model.py` was using deprecated metadata functionality, this removes it

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
