### PR TITLE
fix: multi-out-backward-compatibility

### DIFF
--- a/src/anemoi/inference/runner.py
+++ b/src/anemoi/inference/runner.py
@@ -747,7 +747,9 @@ class Runner(Context):
                 # Update state
                 with ProfilingLabel("Updating state (CPU)", self.use_profiler):
                     for i in range(output.shape[-1]):
-                        new_state["fields"][self.checkpoint.output_tensor_index_to_variable[i]] = output[..., i].squeeze()
+                        new_state["fields"][self.checkpoint.output_tensor_index_to_variable[i]] = output[
+                            ..., i
+                        ].squeeze()
 
                 if (s == 0 and self.verbosity > 0) or self.verbosity > 1:
                     self._print_output_tensor("Output tensor", output.cpu().numpy())


### PR DESCRIPTION
A small change so that anemoi-inference can support the extra dimension in the output being added by multi-out PR https://github.com/ecmwf/anemoi-core/pull/636

I have checked and inference works for both deterministic and ensemble, when trained from both main and the branch in https://github.com/ecmwf/anemoi-core/pull/636

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
