### PR TITLE
feat: provide YAML file to `patch_metadata`

### DIFF
--- a/src/anemoi/inference/config/run.py
+++ b/src/anemoi/inference/config/run.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import datetime
 import logging
+from pathlib import Path
 from typing import Any
 from typing import Literal
 
@@ -105,7 +106,7 @@ class RunConfiguration(Configuration):
     is already loaded when the runner is configured.
     """
 
-    patch_metadata: dict[str, Any] = {}
+    patch_metadata: dict[str, Any] | FilePath = {}
     """A dictionary of metadata to patch the checkpoint metadata with, or a path to a YAML file containing the metadata.
     This is used to test new features or to work around issues with the checkpoint metadata.
     """
@@ -125,10 +126,10 @@ class RunConfiguration(Configuration):
     preload_buffer_size: int = 32 * 1024 * 1024
     """Size of the buffer to use when preloading the checkpoint file, in bytes. Default is 32 MB."""
 
-    @field_validator("patch_metadata", mode="before")
+    @field_validator("patch_metadata", mode="after")
     @classmethod
     def as_dict(cls, patch_metadata: dict | FilePath) -> dict:
-        if isinstance(patch_metadata, str):
+        if isinstance(patch_metadata, Path):
             with open(patch_metadata, "r") as f:
                 patch_metadata = yaml.safe_load(f)
         return patch_metadata

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,5 +1,3 @@
-from tempfile import NamedTemporaryFile
-
 import pytest
 import yaml
 from pytest import MonkeyPatch
@@ -100,17 +98,16 @@ def test_config_dotlist_override_index_error() -> None:
         )
 
 
-def test_config_patch_metadata_file() -> None:
+def test_config_patch_metadata_file(tmp_path) -> None:
     """Test loading the configuration with patch metadata from a file"""
 
     patch_metadata = {"dataset": {"variables_metadata": {"2t": "some_patch"}}}
 
-    with NamedTemporaryFile("w+", delete=True) as tmp:
-        tmp.write(yaml.dump(patch_metadata))
-        tmp.flush()
-        config = RunConfiguration.load(
-            files_for_tests("unit/configs/simple.yaml"),
-            overrides=[f"patch_metadata={tmp.name}"],
-        )
+    patch = tmp_path / "patch.yaml"
+    patch.write_text(yaml.dump(patch_metadata))
+    config = RunConfiguration.load(
+        files_for_tests("unit/configs/simple.yaml"),
+        overrides=[f"patch_metadata={patch}"],
+    )
     assert isinstance(config.patch_metadata, dict)
     assert config.patch_metadata["dataset"]["variables_metadata"]["2t"] == "some_patch"


### PR DESCRIPTION
This PR adds some functionality on the `patch_metadata` configuration in `RunConfiguration` by allowing it to accept either a dictionary or a path to a YAML file. 

* Updated the `patch_metadata` field in `RunConfiguration` to accept either a dictionary or a string path to a YAML file, making it easier to specify and reuse large patches.
* Added a `field_validator` for `patch_metadata` that loads and parses the YAML file if a string path is provided, ensuring the field is always a dictionary at runtime.

---

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
