### PR TITLE
fix(grib): Archive collector wrong `hdate` in mars namespace

### DIFF
--- a/src/anemoi/inference/outputs/gribfile.py
+++ b/src/anemoi/inference/outputs/gribfile.py
@@ -10,7 +10,6 @@
 
 import json
 import logging
-import warnings
 from collections import defaultdict
 from io import IOBase
 from pathlib import Path
@@ -62,16 +61,16 @@ def _fix(mars: dict[str, Any], keys: dict[str, Any]) -> None:
         The keys dictionary.
     """
     if "number" in keys and "number" not in mars:
-        warnings.warn(f"`number` is missing from mars namespace, setting it to {keys['number']}")
+        LOG.debug(f"`number` is missing from mars namespace, setting it to {keys['number']}")
         mars["number"] = keys["number"]
 
     if "dataDate" in keys and "hdate" not in mars:
-        warnings.warn(f"`hdate` is missing from mars namespace, setting it to {keys['dataDate']}")
+        LOG.debug(f"`hdate` is missing from mars namespace, setting it to {keys['dataDate']}")
         mars["hdate"] = keys["dataDate"]
 
     if "startStep" in keys and "endStep" in keys and keys.get("stepType") != "accum":
         if mars.get("step") != f"{keys['startStep']}-{keys['endStep']}":
-            warnings.warn(
+            LOG.debug(
                 f"{keys.get('stepType')} `step={mars.get('step')}` is not a range,  setting it to {keys['startStep']}-{keys['endStep']}."
             )
             mars["step"] = f"{keys['startStep']}-{keys['endStep']}"


### PR DESCRIPTION
## Description
When `hdate` is missing from the mars namespace of the output fields, which can happen when running a hindcast from a dataset, we were setting the wrong value in the archive collector's `hdate`: it should be `dataDate`

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
