### PR TITLE
fix(retrieve): Crash when staging dates due to missing date

### DIFF
--- a/src/anemoi/inference/commands/retrieve.py
+++ b/src/anemoi/inference/commands/retrieve.py
@@ -247,7 +247,8 @@ class RetrieveCmd(Command):
         config: RunConfiguration = RunConfiguration.load(args.config, args.overrides, defaults=args.defaults)
 
         runner = create_runner(config)
-        runner.reference_date = to_datetime(args.date)  # may be used by the runner in patch_data_request
+        if args.date is not None:
+            runner.reference_date = to_datetime(args.date)  # may be used by the runner in patch_data_request
         lead_time = frequency_to_timedelta(config.lead_time)
         time_step = frequency_to_timedelta(runner.checkpoint.timestep)
 


### PR DESCRIPTION
## Description
Already fixed in the multi out interpolator branch, but need it in main too because retrieve staging is broken for all runners. 

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
