### PR TITLE
fix(grib): Archive collector hindcasts wrong `date`

### DIFF
--- a/src/anemoi/inference/outputs/gribfile.py
+++ b/src/anemoi/inference/outputs/gribfile.py
@@ -69,7 +69,7 @@ def _fix(mars: dict[str, Any], keys: dict[str, Any]) -> None:
         mars["hdate"] = keys["dataDate"]
 
     if "referenceDate" in keys and mars.get("date") != keys["referenceDate"]:
-        LOG.debug(f"`date` is wrong in mars namespace, setting it to {keys['referenceDate']}")
+        LOG.debug(f"`date={mars.get('date')}` is wrong in mars namespace, setting it to {keys['referenceDate']}")
         mars["date"] = keys["referenceDate"]
 
     if "startStep" in keys and "endStep" in keys and keys.get("stepType") != "accum":


### PR DESCRIPTION
## Description
Another day, another grib fix. Missed this in #442 , with hindcasts we should also double check that the mars `date` is set to the reference date as it can also be wrong. 

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
