### PR TITLE
fix: Allow accumulation of negative fields.

### DIFF
--- a/src/anemoi/inference/post_processors/accumulate.py
+++ b/src/anemoi/inference/post_processors/accumulate.py
@@ -34,15 +34,23 @@ class Accumulate(Processor):
     accumulations : Optional[List[str]], optional
         List of fields to accumulate, by default None.
         If None, the fields are taken from the context's checkpoint.
+    allow_negative : bool, optional
+        Whether to allow negative values in the accumulation, by default False.
     """
 
-    def __init__(self, context: Context, accumulations: list[str] | None = None) -> None:
+    def __init__(
+        self,
+        context: Context,
+        accumulations: list[str] | None = None,
+        allow_negative: bool = False,
+    ) -> None:
         super().__init__(context)
         if accumulations is None:
             accumulations = context.checkpoint.accumulations
 
         self.accumulations = accumulations
-        LOG.info("Accumulating fields %s", self.accumulations)
+        self.allow_negative = allow_negative
+        LOG.info("Accumulating fields %s (allow_negative=%s)", self.accumulations, self.allow_negative)
 
         self.accumulators: dict[str, FloatArray] = {}
         self.step_zero = timedelta(0)
@@ -66,7 +74,10 @@ class Accumulate(Processor):
             if accumulation in state["fields"]:
                 if accumulation not in self.accumulators:
                     self.accumulators[accumulation] = np.zeros_like(state["fields"][accumulation])
-                self.accumulators[accumulation] += np.maximum(0, state["fields"][accumulation])
+                value = state["fields"][accumulation]
+                if not self.allow_negative:
+                    value = np.maximum(0, value)
+                self.accumulators[accumulation] += value
                 state["fields"][accumulation] = self.accumulators[accumulation]
                 state["start_steps"][accumulation] = self.step_zero
 


### PR DESCRIPTION
## Description
Fixes incorrect accumulation of fields with negative values (e.g. ttr) when using the accumulate_from_start_of_forecast post-processor.

## What problem does this change solve?
Bug fix. The Accumulate post-processor was wrapping all field increments in `np.maximum(0, ...)` before adding them to the running sum. This silently zeroed out negative increments, causing fields like ttr (top-of-atmosphere net thermal radiation) — which are physically allowed to be negative — to output all zeros.

A new allow_negative parameter (default False) is introduced to preserve backwards-compatible behaviour for non-negative fields (e.g. precipitation), while allowing signed accumulation to be opted into per-processor instance:

```
post_processors:
  - accumulate_from_start_of_forecast:
      allow_negative: true
```

## What issue or task does this change relate to?
Temporary fix for #455.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
