### PR TITLE
fix: postproc before open

### DIFF
--- a/src/anemoi/inference/runners/interpolator.py
+++ b/src/anemoi/inference/runners/interpolator.py
@@ -169,10 +169,11 @@ class TimeInterpolatorMultiOutRunner(DefaultRunner):
             input_state = self.create_input_state(date=window_start_date)
 
             self.input_state_hook(input_state)
-            example_output_state = input_state.copy()
+            initial_state = input_state.copy()
             for processor in self.post_processors:
-                example_output_state = processor.process(example_output_state)
-            output.open(example_output_state)
+                initial_state = processor.process(initial_state)
+
+            output.open(initial_state)
 
             # Run interpolation for this window
             for state_idx, state in enumerate(self.run(input_state=input_state, lead_time=self.interpolation_window)):


### PR DESCRIPTION
## Description
Writing to netcdf fails when the postprocessors are affecting the longitudes/latitudes (e.g. extract_mask) of the output. open is called on the initial state with the input lon/lat, so there is a dimension mismatch at the time we write the output.

What problem does this change solve?
This change applies postprocessors before opening the output object.

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
