### PR TITLE
fix: Remove premature version parse

### DIFF
--- a/src/anemoi/inference/provenance.py
+++ b/src/anemoi/inference/provenance.py
@@ -134,7 +134,6 @@ def validate_environment(
     for module in train_environment["module_versions"].keys():
         inference_module_name = module  # Due to package name differences between retrieval methods this may change
 
-        train_module_version_str = version_parser(train_environment["module_versions"][module])
         if not all_packages and "anemoi" not in module:
             continue
         elif module in exempt_packages or module.split(".")[0] in EXEMPT_NAMESPACES:
@@ -153,7 +152,7 @@ def validate_environment(
                 except (ModuleNotFoundError, ImportError):
                     pass
                 invalid_messages["missing"].append(
-                    f"Missing module in inference environment: {module}=={train_module_version_str}"
+                    f"Missing module in inference environment: {module}=={train_environment['module_versions'][module]}"
                 )
                 continue
 
@@ -162,7 +161,7 @@ def validate_environment(
 
         if train_environment_version < inference_environment_version:
             invalid_messages["mismatch"].append(
-                f"Version of module {module} was lower in training than in inference: {train_environment_version!s} <= {inference_environment_version!s}"
+                f"Version of module {module} was lower in training than in inference: {train_environment_version!s} < {inference_environment_version!s}"
             )
         elif train_environment_version > inference_environment_version:
             invalid_messages["critical mismatch"].append(


### PR DESCRIPTION
## Description
Remove premature version parse in environment validation

## What problem does this change solve?
When encountering sys packages the version parsing would break


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
