### PR TITLE
fix: change dimension of latitude and longitude in zarr-output

### DIFF
--- a/src/anemoi/inference/outputs/zarr.py
+++ b/src/anemoi/inference/outputs/zarr.py
@@ -214,7 +214,7 @@ class ZarrOutput(Output):
             name="latitude",
             shape=(values,),
             dtype=self.float_size,
-            dimensions=("latitude",),
+            dimensions=("values",),
             chunks=self.chunks,
             fill_value=self.missing_value,
         )
@@ -226,7 +226,7 @@ class ZarrOutput(Output):
             name="longitude",
             shape=(values,),
             dtype=self.float_size,
-            dimensions=("longitude",),
+            dimensions=("values",),
             chunks=self.chunks,
             fill_value=self.missing_value,
         )


### PR DESCRIPTION
## Description
Currently when using `zarr` output the `latitude` and `longitude` arrays get assigned dimensions `latitude` and `longitude` respectively. This creates two extra (unnecessary) dimensions in the output `zarr`:
`[time, values, longitude, latitude]`.  

This PR assigns the `values` dimension to both latitude and longitude, as is done for `netCDF`-output.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)

BEGIN_COMMIT_OVERRIDE
fix(zarr output): change dimension of latitude and longitude (#479)
END_COMMIT_OVERRIDE