### PR TITLE
feat(zarr output): add support for writing directly to s3-buckets

### DIFF
--- a/src/anemoi/inference/outputs/zarr.py
+++ b/src/anemoi/inference/outputs/zarr.py
@@ -147,21 +147,34 @@ class ZarrOutput(Output):
         import zarr
 
         if isinstance(self.zarr_store, (str, Path)):
-            zarr_store = Path(self.zarr_store)
-            zarr_store.parent.mkdir(parents=True, exist_ok=True)
+            store_str = str(self.zarr_store)
 
-            if zarr_store.exists():
-                LOG.warning(f"Zarr store {self.zarr_store} already exists. It will be overwritten.")
-                shutil.rmtree(self.zarr_store)
+            if "://" in store_str:
+                # Remote store (e.g. S3, GCS) — delegate to fsspec
+                if zarr.__version__ >= "3":
+                    from zarr.storage import FsspecStore
 
-            if zarr.__version__ >= "3":
-                from zarr.storage import LocalStore
+                    self.zarr_store = FsspecStore.from_url(store_str)
+                else:
+                    from zarr.storage import FSStore
 
-                self.zarr_store = LocalStore(self.zarr_store)
+                    self.zarr_store = FSStore(store_str)
             else:
-                from zarr.storage import DirectoryStore
+                zarr_store = Path(self.zarr_store)
+                zarr_store.parent.mkdir(parents=True, exist_ok=True)
 
-                self.zarr_store = DirectoryStore(self.zarr_store)
+                if zarr_store.exists():
+                    LOG.warning(f"Zarr store {self.zarr_store} already exists. It will be overwritten.")
+                    shutil.rmtree(self.zarr_store)
+
+                if zarr.__version__ >= "3":
+                    from zarr.storage import LocalStore
+
+                    self.zarr_store = LocalStore(self.zarr_store)
+                else:
+                    from zarr.storage import DirectoryStore
+
+                    self.zarr_store = DirectoryStore(self.zarr_store)
 
         if zarr.__version__ >= "3":
             self.zarr_group = self.zarr_store


### PR DESCRIPTION
This PR adds support to directly write output to s3-buckets during inference.

relevant part of the config:
```
output:
    zarr: 
       store: s3://my-bucket/my-forecast.zarr
```



***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
