### PR TITLE
fix(patch): Remove outdated import and assert ckpt type

### DIFF
--- a/src/anemoi/inference/commands/patch.py
+++ b/src/anemoi/inference/commands/patch.py
@@ -84,22 +84,27 @@ class PatchCmd(Command):
             The arguments passed to the command.
         """
         from anemoi.utils.checkpoints import load_metadata
-        from anemoi.utils.checkpoints import metadata_root
         from anemoi.utils.checkpoints import replace_metadata
 
         from anemoi.inference.metadata import MetadataFactory
-
-        root = metadata_root(args.path)
+        from anemoi.inference.metadata import SingleDatasetMetadata
 
         original_metadata, original_supporting_arrays = load_metadata(args.path, supporting_arrays=True)
         original_metadata = deepcopy(original_metadata)
         original_supporting_arrays = deepcopy(original_supporting_arrays)
 
-        metadata, supporting_arrays = MetadataFactory(original_metadata).patch_metadata(
-            original_supporting_arrays, root
-        )
+        try:
+            metadata_object = MetadataFactory(original_metadata)
+        except AssertionError:
+            raise AssertionError("Only legacy single-dataset checkpoints are supported for patching at the moment.")
 
-        if diff(metadata, original_metadata) or diff(original_supporting_arrays, supporting_arrays):
+        assert isinstance(
+            metadata_object, SingleDatasetMetadata
+        ), "Only legacy single-dataset checkpoints are supported for patching at the moment."
+
+        metadata, supporting_arrays = metadata_object.patch_metadata(original_supporting_arrays)
+
+        if diff(original_metadata, metadata) or diff(original_supporting_arrays, supporting_arrays):
             LOG.info("Patching metadata")
             assert "sources" in metadata["dataset"]
             replace_metadata(args.path, metadata, supporting_arrays)

--- a/src/anemoi/inference/patch.py
+++ b/src/anemoi/inference/patch.py
@@ -52,7 +52,6 @@ class PatchMixin(MetadataProtocol):
     def patch_metadata(
         self,
         supporting_arrays: dict[str, Any],
-        root: str,
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         """Patch the metadata with supporting arrays and root.
 
@@ -60,8 +59,6 @@ class PatchMixin(MetadataProtocol):
         ----------
         supporting_arrays : dict
             The supporting arrays to patch.
-        root : str
-            The root path for the supporting arrays.
 
         Returns
         -------


### PR DESCRIPTION
## Description
The patch command was still importing a removed function, which was extra silly because it wasn't actually used. Thanks @eliott-lumet for finding the bug!

This also made me aware of the fact that the patch command is incompatible with newer multi-dataset checkpoints (even if they only have a single dataset), since it is not accounting for the new metadata format. 

For now, we only support legacy checkpoint patching because running it on a multi-dataset checkpoint will break certain functionality. I will fix this in the multi-dataset branch or in a follow up PR. 

## What issue or task does this change relate to?
closes #484

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
