### PR TITLE
feat(output): add TensogramOutput for writing .tgm files

### DIFF
--- a/src/anemoi/inference/outputs/tensogram.py
+++ b/src/anemoi/inference/outputs/tensogram.py
@@ -23,19 +23,32 @@ from . import output_registry
 
 LOG = logging.getLogger(__name__)
 
+# Written into base[i]["name"] for lat/lon objects.  These names are
+# deliberately NOT in tensogram-xarray's KNOWN_COORD_NAMES so that lat/lon
+# objects share the same flat dimension as all field objects rather than each
+# spawning its own dimension.  The canonical names are preserved in the "anemoi"
+# namespace for downstream consumers.
+_COORD_NAME_MAP = {
+    "latitude": "grid_latitude",
+    "longitude": "grid_longitude",
+}
+
 
 @output_registry.register("tensogram")
 @main_argument("path")
 class TensogramOutput(Output):
     """Tensogram output class.
 
-    Writes each forecast step as one tensogram message appended to a .tgm file.
-    Each message contains lat/lon coordinate objects followed by one object per
-    field (or one stacked object per pressure-level parameter when
-    ``stack_pressure_levels=True``).
+    Writes each forecast step as one tensogram message appended to a .tgm file
+    or streamed over a TCP socket.  Each message contains lat/lon coordinate
+    objects followed by one object per field (or one stacked object per
+    pressure-level parameter when ``stack_pressure_levels=True``).
 
     Per-object metadata is stored under the ``"anemoi"`` namespace in CBOR.
     Message-level metadata (date, step) is stored in ``_extra_["anemoi"]``.
+    Dimension-name hints are stored in ``_extra_["dim_names"]`` so the
+    tensogram-xarray backend can resolve meaningful names without the reader
+    having to pass ``dim_names`` explicitly.
 
     Supports local paths and remote URLs (s3://, gs://, az://, ...) via fsspec.
     Each step is encoded and written immediately -- no full-forecast buffering.
@@ -43,10 +56,10 @@ class TensogramOutput(Output):
     Pressure-level stacking
     -----------------------
     When ``stack_pressure_levels=True``, all fields sharing the same ``param``
-    and ``levtype="pl"`` are stacked into a single 2-D object of shape
-    ``(n_levels, n_grid)``, sorted by level in ascending order.  The
-    per-object metadata stores ``"levels": [500, 850, ...]`` (plural) instead
-    of the scalar ``"level"`` key used for unstacked fields.
+    are stacked into a single 2-D object of shape ``(n_grid, n_levels)``,
+    sorted by level in ascending order.  The per-object metadata stores
+    ``"levels": [500, 850, ...]`` (plural) instead of the scalar ``"level"``
+    key used for unstacked fields.
 
     Without stacking (default), every field is a separate 1-D object and the
     scalar ``"level"`` key is always stored when it is present in the
@@ -75,7 +88,11 @@ class TensogramOutput(Output):
         context : Context
             The forecast context.
         path : str
-            Destination path. Local file path or remote URL (s3://, gs://, az://, ...).
+            Destination path:
+
+            * Local file path -- e.g. ``"forecast.tgm"`` or ``"/data/out.tgm"``
+            * Remote object-store URL -- e.g. ``"s3://bucket/out.tgm"``,
+              ``"gs://..."``, ``"az://..."``
         encoding : str, optional
             Encoding stage: "none" (default) or "simple_packing".
         bits : int | None, optional
@@ -87,10 +104,11 @@ class TensogramOutput(Output):
             Coordinate arrays (lat/lon) are always float64.
             When encoding="simple_packing", arrays are promoted to float64 automatically.
         storage_options : dict | None, optional
-            Options forwarded to fsspec for remote destinations (credentials, etc.).
+            Options forwarded to fsspec for remote destinations (credentials,
+            region, endpoint overrides, etc.).  Ignored for local files.
         stack_pressure_levels : bool, optional
-            When True, fields with levtype="pl" sharing the same param are stacked
-            into a single (n_levels, n_grid) object sorted by level ascending.
+            When True, pressure-level fields sharing the same param are stacked
+            into a single (n_grid, n_levels) object sorted by level ascending.
             Metadata stores ``"levels": [...]`` (plural).  Default False.
         variables : list[str] | None, optional
             Restrict output to this subset of variables. None means all variables.
@@ -133,8 +151,12 @@ class TensogramOutput(Output):
     def open(self, state: State) -> None:
         """Open the output stream.
 
-        For local paths, creates parent directories and opens a binary file.
-        For remote URLs, opens a writable fsspec stream.
+        For local paths, creates parent directories and opens a binary file
+        via fsspec.  For remote URLs (``s3://``, ``gs://``, ``az://``, ...),
+        opens a writable fsspec stream.
+
+        ``@ensure_path`` is intentionally not used so that ``self.path`` stays
+        a ``str``; the fsspec path detection relies on string prefix checks.
         """
         import fsspec
 
@@ -154,6 +176,9 @@ class TensogramOutput(Output):
 
     def write_step(self, state: State) -> None:
         """Encode one forecast step as a tensogram message and write it immediately."""
+        if self._handle is None:
+            raise RuntimeError(f"{self!r}: write_step called before open() or after close()")
+
         global_meta = {
             "version": 2,
             "base": [],
@@ -167,13 +192,6 @@ class TensogramOutput(Output):
         descriptors_and_data = []
 
         # Coordinate objects -- always float64, no lossy encoding.
-        # "name" uses "grid_latitude"/"grid_longitude" (not in KNOWN_COORD_NAMES)
-        # so all objects share one flat dimension rather than each coord getting
-        # its own dimension.  The "anemoi" namespace preserves the canonical name.
-        _COORD_NAME_MAP = {
-            "latitude": "grid_latitude",
-            "longitude": "grid_longitude",
-        }
         for coord_name, coord_arr in [
             ("latitude", state["latitudes"]),
             ("longitude", state["longitudes"]),
@@ -198,15 +216,18 @@ class TensogramOutput(Output):
         else:
             self._add_fields_flat(state, global_meta, descriptors_and_data)
 
-        # Embed dimension-name hints in _extra_["dim_names"] (generic, no namespace)
-        # so the tensogram-xarray backend can replace dim_N fallback names.
-        # Grid axis → "values"; level axis (2-D stacked objects) → "level".
+        # Embed dimension-name hints in _extra_["dim_names"] (generic, no
+        # namespace) so the tensogram-xarray backend can replace dim_N fallback
+        # names.  Grid axis → "values".  When stacking, also map each unique
+        # level-axis size → "level".
         n_grid = len(state["latitudes"])
         dim_names_hint: dict[str, str] = {str(n_grid): "values"}
-        for _, arr in descriptors_and_data:
-            if arr.ndim == 2:
-                dim_names_hint[str(arr.shape[1])] = "level"
-                break
+        if self.stack_pressure_levels:
+            for _, arr in descriptors_and_data:
+                if arr.ndim == 2:
+                    level_size = str(arr.shape[1])
+                    if level_size not in dim_names_hint:
+                        dim_names_hint[level_size] = "level"
         global_meta["_extra_"]["dim_names"] = dim_names_hint
 
         import tensogram
@@ -217,6 +238,10 @@ class TensogramOutput(Output):
     def close(self) -> None:
         """Flush and close the output stream."""
         if self._handle is not None:
+            try:
+                self._handle.flush()
+            except Exception:
+                pass
             self._handle.close()
             self._handle = None
 
@@ -235,6 +260,8 @@ class TensogramOutput(Output):
             if self.skip_variable(name):
                 continue
             variable = self.typed_variables.get(name)
+            if variable is None:
+                LOG.warning("TensogramOutput: no typed variable for %r -- metadata will be incomplete", name)
             grib = getattr(variable, "grib_keys", {}) if variable else {}
             base_entry, descriptor, arr = self._build_field_object(name, grib, values)
             global_meta["base"].append(base_entry)
@@ -255,6 +282,8 @@ class TensogramOutput(Output):
             if self.skip_variable(name):
                 continue
             variable = self.typed_variables.get(name)
+            if variable is None:
+                LOG.warning("TensogramOutput: no typed variable for %r -- metadata will be incomplete", name)
             grib = getattr(variable, "grib_keys", {}) if variable else {}
             if variable is not None and variable.is_pressure_level:
                 param = variable.param
@@ -263,7 +292,7 @@ class TensogramOutput(Output):
             else:
                 non_pl.append((name, grib, values))
 
-        if self.stack_pressure_levels and not pl_groups:
+        if not pl_groups:
             LOG.warning("TensogramOutput: stack_pressure_levels=True but no pressure-level fields found")
 
         # Non-PL fields: one object each.
@@ -337,20 +366,24 @@ class TensogramOutput(Output):
         param : str
             The shared GRIB parameter name for this group.
         group : list
-            Sorted list of ``(level, variable_name, grib_keys, values)`` tuples.
+            Sorted list of ``(level, variable_name, grib_keys, values)`` tuples,
+            already sorted by level ascending.
 
         Returns
         -------
         tuple[dict, dict, np.ndarray]
             ``(base_entry, descriptor, array)`` ready to append to the message.
+            The array has shape ``(n_grid, n_levels)`` -- grid axis first so that
+            all objects in the message share the same leading dimension in the
+            tensogram-xarray backend.
         """
         levels = [item[0] for item in group]
         first_grib = group[0][2]
 
         arrays = [self._prepare_array(item[3]) for item in group]
-        # Shape (n_grid, n_levels): grid axis first so all objects share dim_0
-        # in the tensogram-xarray backend (which assigns dim names by axis position).
-        stacked = np.column_stack(arrays)  # (n_grid, n_levels)
+        # (n_grid, n_levels): grid axis first so all objects share dim "values"
+        # in the tensogram-xarray backend.
+        stacked = np.column_stack(arrays)
 
         anemoi_meta = {
             "variable": param,

--- a/src/anemoi/inference/outputs/tensogram.py
+++ b/src/anemoi/inference/outputs/tensogram.py
@@ -196,7 +196,8 @@ class TensogramOutput(Output):
         step_hours = int(step_seconds / 3600) if step_seconds % 3600 == 0 else step_seconds / 3600
         base_dt = state["date"] - state["step"]
         mars_extra = {
-            "basedatetime": base_dt.isoformat(),
+            "date": base_dt.strftime("%Y%m%d"),
+            "time": base_dt.strftime("%H%M"),
             "step": step_hours,
         }
 
@@ -381,7 +382,7 @@ class TensogramOutput(Output):
             Sorted list of ``(level, variable_name, grib_keys, values)`` tuples,
             already sorted by level ascending.
         mars_extra : dict
-            Per-message MARS keys (``basedatetime``, ``step``) merged into
+            Per-message MARS keys (``date``, ``time``, ``step``) merged into
             ``base[i]["mars"]`` for every object.
 
         Returns

--- a/src/anemoi/inference/outputs/tensogram.py
+++ b/src/anemoi/inference/outputs/tensogram.py
@@ -1,0 +1,362 @@
+# (C) Copyright 2025 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import logging
+from functools import cached_property
+from pathlib import Path
+
+import numpy as np
+
+from anemoi.inference.context import Context
+from anemoi.inference.types import ProcessorConfig
+from anemoi.inference.types import State
+
+from ..decorators import main_argument
+from ..output import Output
+from . import output_registry
+
+LOG = logging.getLogger(__name__)
+
+
+@output_registry.register("tensogram")
+@main_argument("path")
+class TensogramOutput(Output):
+    """Tensogram output class.
+
+    Writes each forecast step as one tensogram message appended to a .tgm file.
+    Each message contains lat/lon coordinate objects followed by one object per
+    field (or one stacked object per pressure-level parameter when
+    ``stack_pressure_levels=True``).
+
+    Per-object metadata is stored under the ``"anemoi"`` namespace in CBOR.
+    Message-level metadata (date, step) is stored in ``_extra_["anemoi"]``.
+
+    Supports local paths and remote URLs (s3://, gs://, az://, ...) via fsspec.
+    Each step is encoded and written immediately -- no full-forecast buffering.
+
+    Pressure-level stacking
+    -----------------------
+    When ``stack_pressure_levels=True``, all fields sharing the same ``param``
+    and ``levtype="pl"`` are stacked into a single 2-D object of shape
+    ``(n_levels, n_grid)``, sorted by level in ascending order.  The
+    per-object metadata stores ``"levels": [500, 850, ...]`` (plural) instead
+    of the scalar ``"level"`` key used for unstacked fields.
+
+    Without stacking (default), every field is a separate 1-D object and the
+    scalar ``"level"`` key is always stored when it is present in the
+    checkpoint's GRIB keys.
+    """
+
+    def __init__(
+        self,
+        context: Context,
+        path: str,
+        encoding: str = "none",
+        bits: int | None = None,
+        compression: str = "zstd",
+        dtype: str = "float32",
+        storage_options: dict | None = None,
+        stack_pressure_levels: bool = False,
+        variables: list[str] | None = None,
+        post_processors: list[ProcessorConfig] | None = None,
+        output_frequency: int | None = None,
+        write_initial_state: bool | None = None,
+    ) -> None:
+        """Initialise TensogramOutput.
+
+        Parameters
+        ----------
+        context : Context
+            The forecast context.
+        path : str
+            Destination path. Local file path or remote URL (s3://, gs://, az://, ...).
+        encoding : str, optional
+            Encoding stage: "none" (default) or "simple_packing".
+        bits : int | None, optional
+            Bits per value for "simple_packing". Required when encoding="simple_packing".
+        compression : str, optional
+            Compression codec: "none", "zstd" (default), "lz4", "szip", "blosc2".
+        dtype : str, optional
+            Output dtype for field arrays: "float32" (default) or "float64".
+            Coordinate arrays (lat/lon) are always float64.
+            When encoding="simple_packing", arrays are promoted to float64 automatically.
+        storage_options : dict | None, optional
+            Options forwarded to fsspec for remote destinations (credentials, etc.).
+        stack_pressure_levels : bool, optional
+            When True, fields with levtype="pl" sharing the same param are stacked
+            into a single (n_levels, n_grid) object sorted by level ascending.
+            Metadata stores ``"levels": [...]`` (plural).  Default False.
+        variables : list[str] | None, optional
+            Restrict output to this subset of variables. None means all variables.
+        post_processors : list[ProcessorConfig] | None, optional
+            Post-processors applied to each state before writing.
+        output_frequency : int | None, optional
+            Write every N steps. None means every step.
+        write_initial_state : bool | None, optional
+            Whether to write the initial state (step 0).
+        """
+        super().__init__(
+            context,
+            variables=variables,
+            post_processors=post_processors,
+            output_frequency=output_frequency,
+            write_initial_state=write_initial_state,
+        )
+        self.path = path
+        self.encoding = encoding
+        self.bits = bits
+        self.compression = compression
+        self.dtype = dtype
+        self.storage_options = storage_options or {}
+        self.stack_pressure_levels = stack_pressure_levels
+        self._handle = None
+
+    def __repr__(self) -> str:
+        return f"TensogramOutput({self.path})"
+
+    @cached_property
+    def _numpy_dtype(self) -> np.dtype:
+        return np.dtype(self.dtype)
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def open(self, state: State) -> None:
+        """Open the output stream.
+
+        For local paths, creates parent directories and opens a binary file.
+        For remote URLs, opens a writable fsspec stream.
+        """
+        import fsspec
+
+        path_str = str(self.path)
+        if "://" not in path_str:
+            Path(path_str).parent.mkdir(parents=True, exist_ok=True)
+
+        self._handle = fsspec.open(path_str, "wb", **self.storage_options).open()
+        LOG.info("TensogramOutput: writing to %s", path_str)
+
+    def write_initial_state(self, state: State) -> None:
+        """Write the initial state, reducing multi-step fields to the last step."""
+        from anemoi.inference.state import reduce_state
+
+        state = reduce_state(state)
+        return super().write_initial_state(state)
+
+    def write_step(self, state: State) -> None:
+        """Encode one forecast step as a tensogram message and write it immediately."""
+        global_meta = {
+            "version": 2,
+            "base": [],
+            "_extra_": {
+                "anemoi": {
+                    "date": state["date"].isoformat(),
+                    "step": state["step"].total_seconds(),
+                }
+            },
+        }
+        descriptors_and_data = []
+
+        # Coordinate objects -- always float64, no lossy encoding.
+        # "name" uses "grid_latitude"/"grid_longitude" (not in KNOWN_COORD_NAMES)
+        # so all objects share one flat dimension rather than each coord getting
+        # its own dimension.  The "anemoi" namespace preserves the canonical name.
+        _COORD_NAME_MAP = {
+            "latitude": "grid_latitude",
+            "longitude": "grid_longitude",
+        }
+        for coord_name, coord_arr in [
+            ("latitude", state["latitudes"]),
+            ("longitude", state["longitudes"]),
+        ]:
+            arr = np.asarray(coord_arr, dtype=np.float64)
+            global_meta["base"].append(
+                {
+                    "name": _COORD_NAME_MAP[coord_name],
+                    "anemoi": {"variable": coord_name},
+                }
+            )
+            descriptors_and_data.append(
+                (
+                    {"type": "ntensor", "shape": list(arr.shape), "dtype": "float64"},
+                    arr,
+                )
+            )
+
+        # Field objects.
+        if self.stack_pressure_levels:
+            self._add_fields_stacked(state, global_meta, descriptors_and_data)
+        else:
+            self._add_fields_flat(state, global_meta, descriptors_and_data)
+
+        # Embed dimension-name hints in _extra_["dim_names"] (generic, no namespace)
+        # so the tensogram-xarray backend can replace dim_N fallback names.
+        # Grid axis → "values"; level axis (2-D stacked objects) → "level".
+        n_grid = len(state["latitudes"])
+        dim_names_hint: dict[str, str] = {str(n_grid): "values"}
+        for _, arr in descriptors_and_data:
+            if arr.ndim == 2:
+                dim_names_hint[str(arr.shape[1])] = "level"
+                break
+        global_meta["_extra_"]["dim_names"] = dim_names_hint
+
+        import tensogram
+
+        msg_bytes = tensogram.encode(global_meta, descriptors_and_data)
+        self._handle.write(msg_bytes)
+
+    def close(self) -> None:
+        """Flush and close the output stream."""
+        if self._handle is not None:
+            self._handle.close()
+            self._handle = None
+
+    # ------------------------------------------------------------------
+    # Field object builders
+    # ------------------------------------------------------------------
+
+    def _add_fields_flat(
+        self,
+        state: State,
+        global_meta: dict,
+        descriptors_and_data: list,
+    ) -> None:
+        """Add one object per field (default, no stacking)."""
+        for name, values in state["fields"].items():
+            if self.skip_variable(name):
+                continue
+            variable = self.typed_variables.get(name)
+            grib = getattr(variable, "grib_keys", {}) if variable else {}
+            base_entry, descriptor, arr = self._build_field_object(name, grib, values)
+            global_meta["base"].append(base_entry)
+            descriptors_and_data.append((descriptor, arr))
+
+    def _add_fields_stacked(
+        self,
+        state: State,
+        global_meta: dict,
+        descriptors_and_data: list,
+    ) -> None:
+        """Group pressure-level fields by param and stack; write others flat."""
+        # pl_groups[param] = [(level, name, grib, values), ...]
+        pl_groups: dict[str, list[tuple[int, str, dict, np.ndarray]]] = {}
+        non_pl: list[tuple[str, dict, np.ndarray]] = []
+
+        for name, values in state["fields"].items():
+            if self.skip_variable(name):
+                continue
+            variable = self.typed_variables.get(name)
+            grib = getattr(variable, "grib_keys", {}) if variable else {}
+            if variable is not None and variable.is_pressure_level:
+                param = variable.param
+                level = variable.level
+                pl_groups.setdefault(param, []).append((level, name, grib, values))
+            else:
+                non_pl.append((name, grib, values))
+
+        if self.stack_pressure_levels and not pl_groups:
+            LOG.warning("TensogramOutput: stack_pressure_levels=True but no pressure-level fields found")
+
+        # Non-PL fields: one object each.
+        for name, grib, values in non_pl:
+            base_entry, descriptor, arr = self._build_field_object(name, grib, values)
+            global_meta["base"].append(base_entry)
+            descriptors_and_data.append((descriptor, arr))
+
+        # PL groups: one stacked object per param, sorted by level ascending.
+        for param in sorted(pl_groups):
+            group = sorted(pl_groups[param], key=lambda x: x[0])
+            base_entry, descriptor, arr = self._build_stacked_object(param, group)
+            global_meta["base"].append(base_entry)
+            descriptors_and_data.append((descriptor, arr))
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _prepare_array(self, values: np.ndarray) -> np.ndarray:
+        """Cast values to the configured dtype, promoting to float64 for simple_packing."""
+        arr = np.asarray(values, dtype=self._numpy_dtype)
+        if self.encoding == "simple_packing":
+            arr = arr.astype(np.float64)
+        return arr
+
+    def _build_descriptor(self, arr: np.ndarray) -> dict:
+        """Build the tensogram descriptor dict for a prepared array."""
+        descriptor = {
+            "type": "ntensor",
+            "shape": list(arr.shape),
+            "dtype": arr.dtype.name,
+            "encoding": self.encoding,
+            "compression": self.compression,
+        }
+        if self.encoding == "simple_packing" and self.bits is not None:
+            import tensogram
+
+            # compute_packing_params requires a 1-D float64 array.
+            sp_params = tensogram.compute_packing_params(arr.ravel(), self.bits, 0)
+            descriptor.update(sp_params)
+        return descriptor
+
+    def _build_field_object(
+        self,
+        name: str,
+        grib: dict,
+        values: np.ndarray,
+    ) -> tuple[dict, dict, np.ndarray]:
+        """Build (base_entry, descriptor, array) for a single flat field object."""
+        anemoi_meta = {"variable": name, "param": grib.get("param", name)}
+        for k in ("levtype", "level"):
+            if k in grib:
+                anemoi_meta[k] = grib[k]
+
+        # "name" at the top level lets the tensogram-xarray backend resolve
+        # the variable name without knowing the "anemoi" namespace.
+        base_entry = {"name": name, "anemoi": anemoi_meta}
+        arr = self._prepare_array(values)
+        return base_entry, self._build_descriptor(arr), arr
+
+    def _build_stacked_object(
+        self,
+        param: str,
+        group: list[tuple[int, str, dict, np.ndarray]],
+    ) -> tuple[dict, dict, np.ndarray]:
+        """Build (base_entry, descriptor, array) for a stacked pressure-level object.
+
+        Parameters
+        ----------
+        param : str
+            The shared GRIB parameter name for this group.
+        group : list
+            Sorted list of ``(level, variable_name, grib_keys, values)`` tuples.
+
+        Returns
+        -------
+        tuple[dict, dict, np.ndarray]
+            ``(base_entry, descriptor, array)`` ready to append to the message.
+        """
+        levels = [item[0] for item in group]
+        first_grib = group[0][2]
+
+        arrays = [self._prepare_array(item[3]) for item in group]
+        # Shape (n_grid, n_levels): grid axis first so all objects share dim_0
+        # in the tensogram-xarray backend (which assigns dim names by axis position).
+        stacked = np.column_stack(arrays)  # (n_grid, n_levels)
+
+        anemoi_meta = {
+            "variable": param,
+            "param": param,
+            "levtype": first_grib.get("levtype", "pl"),
+            "levels": levels,
+        }
+        # "name" at the top level lets the tensogram-xarray backend resolve
+        # the variable name without knowing the "anemoi" namespace.
+        base_entry = {"name": param, "anemoi": anemoi_meta}
+        return base_entry, self._build_descriptor(stacked), stacked

--- a/src/anemoi/inference/outputs/tensogram.py
+++ b/src/anemoi/inference/outputs/tensogram.py
@@ -191,6 +191,15 @@ class TensogramOutput(Output):
         }
         descriptors_and_data = []
 
+        # Per-field MARS keys that are the same for every object in this message.
+        step_seconds = state["step"].total_seconds()
+        step_hours = int(step_seconds / 3600) if step_seconds % 3600 == 0 else step_seconds / 3600
+        base_dt = state["date"] - state["step"]
+        mars_extra = {
+            "basedatetime": base_dt.isoformat(),
+            "step": step_hours,
+        }
+
         # Coordinate objects -- always float64, no lossy encoding.
         for coord_name, coord_arr in [
             ("latitude", state["latitudes"]),
@@ -212,9 +221,9 @@ class TensogramOutput(Output):
 
         # Field objects.
         if self.stack_pressure_levels:
-            self._add_fields_stacked(state, global_meta, descriptors_and_data)
+            self._add_fields_stacked(state, global_meta, descriptors_and_data, mars_extra)
         else:
-            self._add_fields_flat(state, global_meta, descriptors_and_data)
+            self._add_fields_flat(state, global_meta, descriptors_and_data, mars_extra)
 
         # Embed dimension-name hints in _extra_["dim_names"] (generic, no
         # namespace) so the tensogram-xarray backend can replace dim_N fallback
@@ -254,6 +263,7 @@ class TensogramOutput(Output):
         state: State,
         global_meta: dict,
         descriptors_and_data: list,
+        mars_extra: dict,
     ) -> None:
         """Add one object per field (default, no stacking)."""
         for name, values in state["fields"].items():
@@ -263,7 +273,7 @@ class TensogramOutput(Output):
             if variable is None:
                 LOG.warning("TensogramOutput: no typed variable for %r -- metadata will be incomplete", name)
             grib = getattr(variable, "grib_keys", {}) if variable else {}
-            base_entry, descriptor, arr = self._build_field_object(name, grib, values)
+            base_entry, descriptor, arr = self._build_field_object(name, grib, values, mars_extra)
             global_meta["base"].append(base_entry)
             descriptors_and_data.append((descriptor, arr))
 
@@ -272,6 +282,7 @@ class TensogramOutput(Output):
         state: State,
         global_meta: dict,
         descriptors_and_data: list,
+        mars_extra: dict,
     ) -> None:
         """Group pressure-level fields by param and stack; write others flat."""
         # pl_groups[param] = [(level, name, grib, values), ...]
@@ -297,14 +308,14 @@ class TensogramOutput(Output):
 
         # Non-PL fields: one object each.
         for name, grib, values in non_pl:
-            base_entry, descriptor, arr = self._build_field_object(name, grib, values)
+            base_entry, descriptor, arr = self._build_field_object(name, grib, values, mars_extra)
             global_meta["base"].append(base_entry)
             descriptors_and_data.append((descriptor, arr))
 
         # PL groups: one stacked object per param, sorted by level ascending.
         for param in sorted(pl_groups):
             group = sorted(pl_groups[param], key=lambda x: x[0])
-            base_entry, descriptor, arr = self._build_stacked_object(param, group)
+            base_entry, descriptor, arr = self._build_stacked_object(param, group, mars_extra)
             global_meta["base"].append(base_entry)
             descriptors_and_data.append((descriptor, arr))
 
@@ -341,16 +352,16 @@ class TensogramOutput(Output):
         name: str,
         grib: dict,
         values: np.ndarray,
+        mars_extra: dict,
     ) -> tuple[dict, dict, np.ndarray]:
         """Build (base_entry, descriptor, array) for a single flat field object."""
-        anemoi_meta = {"variable": name, "param": grib.get("param", name)}
-        for k in ("levtype", "level"):
-            if k in grib:
-                anemoi_meta[k] = grib[k]
-
         # "name" at the top level lets the tensogram-xarray backend resolve
         # the variable name without knowing the "anemoi" namespace.
-        base_entry = {"name": name, "anemoi": anemoi_meta}
+        # MARS keys go under "mars" following tensogram-grib convention.
+        mars = {**mars_extra, **grib}
+        base_entry: dict = {"name": name, "anemoi": {"variable": name}}
+        if mars:
+            base_entry["mars"] = mars
         arr = self._prepare_array(values)
         return base_entry, self._build_descriptor(arr), arr
 
@@ -358,6 +369,7 @@ class TensogramOutput(Output):
         self,
         param: str,
         group: list[tuple[int, str, dict, np.ndarray]],
+        mars_extra: dict,
     ) -> tuple[dict, dict, np.ndarray]:
         """Build (base_entry, descriptor, array) for a stacked pressure-level object.
 
@@ -368,6 +380,9 @@ class TensogramOutput(Output):
         group : list
             Sorted list of ``(level, variable_name, grib_keys, values)`` tuples,
             already sorted by level ascending.
+        mars_extra : dict
+            Per-message MARS keys (``basedatetime``, ``step``) merged into
+            ``base[i]["mars"]`` for every object.
 
         Returns
         -------
@@ -385,13 +400,13 @@ class TensogramOutput(Output):
         # in the tensogram-xarray backend.
         stacked = np.column_stack(arrays)
 
-        anemoi_meta = {
-            "variable": param,
-            "param": param,
-            "levtype": first_grib.get("levtype", "pl"),
-            "levels": levels,
-        }
+        # MARS keys follow tensogram-grib convention; omit scalar "level"
+        # since this object spans multiple levels.
+        mars = {**mars_extra, **{k: v for k, v in first_grib.items() if k != "level"}}
+
         # "name" at the top level lets the tensogram-xarray backend resolve
         # the variable name without knowing the "anemoi" namespace.
-        base_entry = {"name": param, "anemoi": anemoi_meta}
+        base_entry: dict = {"name": param, "anemoi": {"variable": param, "levels": levels}}
+        if mars:
+            base_entry["mars"] = mars
         return base_entry, self._build_descriptor(stacked), stacked

--- a/src/anemoi/inference/outputs/tensogram.py
+++ b/src/anemoi/inference/outputs/tensogram.py
@@ -108,6 +108,8 @@ class TensogramOutput(Output):
             output_frequency=output_frequency,
             write_initial_state=write_initial_state,
         )
+        if encoding == "simple_packing" and bits is None:
+            raise ValueError("bits must be set when encoding='simple_packing'")
         self.path = path
         self.encoding = encoding
         self.bits = bits

--- a/tests/unit/test_tensogram_output.py
+++ b/tests/unit/test_tensogram_output.py
@@ -1,0 +1,505 @@
+# (C) Copyright 2025 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Tests for TensogramOutput."""
+
+from datetime import datetime
+from datetime import timedelta
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from anemoi.inference.outputs.tensogram import TensogramOutput
+
+tensogram = pytest.importorskip("tensogram", reason="tensogram not installed")
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+N_GRID = 100
+FIELD_NAMES = ["2t", "10u", "10v"]
+
+
+def _make_variable(param=None, levtype=None, level=None):
+    grib = {"param": param} if param is not None else {}
+    if levtype is not None:
+        grib["levtype"] = levtype
+    if level is not None:
+        grib["level"] = level
+    is_pl = levtype is not None and level is not None
+    return SimpleNamespace(
+        grib_keys=grib,
+        is_computed_forcing=False,
+        is_pressure_level=is_pl,
+        param=param,
+        level=level,
+    )
+
+
+def _make_context(field_names=FIELD_NAMES):
+    typed_variables = {name: _make_variable(param=name) for name in field_names}
+
+    checkpoint = SimpleNamespace(
+        typed_variables=typed_variables,
+    )
+    context = SimpleNamespace(
+        checkpoint=checkpoint,
+        reference_date=datetime(2024, 1, 1),
+        write_initial_state=False,
+        output_frequency=None,
+        typed_variables={},
+    )
+    return context
+
+
+def _make_state(step_hours=1, field_names=FIELD_NAMES, n_grid=N_GRID, seed=0):
+    rng = np.random.default_rng(seed)
+    date = datetime(2024, 1, 1) + timedelta(hours=step_hours)
+    return {
+        "date": date,
+        "step": timedelta(hours=step_hours),
+        "latitudes": np.linspace(-90, 90, n_grid, dtype=np.float64),
+        "longitudes": np.linspace(0, 360, n_grid, dtype=np.float64),
+        "fields": {name: rng.random(n_grid).astype(np.float32) for name in field_names},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_write_and_read_local(tmp_path):
+    """Write 3 steps to a local .tgm file and verify round-trip."""
+    path = tmp_path / "forecast.tgm"
+    context = _make_context()
+    output = TensogramOutput(context, str(path))
+
+    states = [_make_state(h) for h in range(1, 4)]
+    output.open(states[0])
+    for state in states:
+        output.write_step(state)
+    output.close()
+
+    assert path.exists()
+
+    tgm_file = tensogram.TensogramFile.open(str(path))
+    assert len(tgm_file) == 3
+
+    for i, msg in enumerate(tgm_file):
+        meta, objects = msg
+
+        # lat + lon + 3 fields = 5 objects per message
+        assert len(objects) == 5
+
+        # Coordinate objects -- "name" uses "grid_*" to avoid KNOWN_COORD_NAMES
+        # so all objects share one flat dimension in the xarray backend.
+        assert meta.base[0]["name"] == "grid_latitude"
+        assert meta.base[1]["name"] == "grid_longitude"
+        assert meta.base[0]["anemoi"]["variable"] == "latitude"
+        assert meta.base[1]["anemoi"]["variable"] == "longitude"
+        lat_desc, lat_arr = objects[0]
+        lon_desc, lon_arr = objects[1]
+        assert lat_desc.dtype == "float64"
+        assert lon_desc.dtype == "float64"
+        np.testing.assert_allclose(lat_arr, states[i]["latitudes"])
+        np.testing.assert_allclose(lon_arr, states[i]["longitudes"])
+
+        # Field objects -- "name" top-level for xarray backend.
+        for j, name in enumerate(FIELD_NAMES):
+            obj_idx = 2 + j
+            assert meta.base[obj_idx]["name"] == name
+            assert meta.base[obj_idx]["anemoi"]["variable"] == name
+            assert meta.base[obj_idx]["anemoi"]["param"] == name
+            _, field_arr = objects[obj_idx]
+            np.testing.assert_allclose(field_arr, states[i]["fields"][name], rtol=1e-6)
+
+        # Extra metadata
+        extra = meta.extra["anemoi"]
+        assert extra["step"] == states[i]["step"].total_seconds()
+        assert extra["date"] == states[i]["date"].isoformat()
+
+
+def test_variable_filter(tmp_path):
+    """Only the selected variable and coordinates are written."""
+    path = tmp_path / "filtered.tgm"
+    context = _make_context()
+    output = TensogramOutput(context, str(path), variables=["2t"])
+
+    state = _make_state()
+    output.open(state)
+    output.write_step(state)
+    output.close()
+
+    tgm_file = tensogram.TensogramFile.open(str(path))
+    msg = tgm_file[0]
+    meta, objects = msg
+
+    # lat + lon + 1 filtered field
+    assert len(objects) == 3
+    assert meta.base[2]["anemoi"]["variable"] == "2t"
+
+
+def test_simple_packing_encoding(tmp_path):
+    """simple_packing round-trip stays within expected quantisation error."""
+    path = tmp_path / "packed.tgm"
+    context = _make_context(["2t"])
+    output = TensogramOutput(context, str(path), encoding="simple_packing", bits=16, compression="zstd")
+
+    rng = np.random.default_rng(42)
+    values = (rng.random(N_GRID) * 50 + 250).astype(np.float32)  # ~250-300 K range
+    state = {
+        "date": datetime(2024, 1, 1, 1),
+        "step": timedelta(hours=1),
+        "latitudes": np.linspace(-90, 90, N_GRID, dtype=np.float64),
+        "longitudes": np.linspace(0, 360, N_GRID, dtype=np.float64),
+        "fields": {"2t": values},
+    }
+
+    output.open(state)
+    output.write_step(state)
+    output.close()
+
+    tgm_file = tensogram.TensogramFile.open(str(path))
+    meta, objects = tgm_file[0]
+    _, decoded = objects[2]  # index 0=lat, 1=lon, 2=2t
+
+    # 16-bit packing over a 50 K range: max error ≈ 50/65535 ≈ 0.001 K
+    np.testing.assert_allclose(decoded, values, atol=0.002)
+
+
+def test_grib_metadata_forwarded(tmp_path):
+    """level/levtype from grib_keys appear in per-object anemoi metadata."""
+    path = tmp_path / "levs.tgm"
+    typed_variables = {
+        "t500": _make_variable(param="t", levtype="pl", level=500),
+    }
+    checkpoint = SimpleNamespace(typed_variables=typed_variables)
+    context = SimpleNamespace(
+        checkpoint=checkpoint,
+        reference_date=datetime(2024, 1, 1),
+        write_initial_state=False,
+        output_frequency=None,
+        typed_variables={},
+    )
+
+    output = TensogramOutput(context, str(path))
+    state = {
+        "date": datetime(2024, 1, 1, 1),
+        "step": timedelta(hours=1),
+        "latitudes": np.zeros(10, dtype=np.float64),
+        "longitudes": np.zeros(10, dtype=np.float64),
+        "fields": {"t500": np.ones(10, dtype=np.float32)},
+    }
+    output.open(state)
+    output.write_step(state)
+    output.close()
+
+    tgm_file = tensogram.TensogramFile.open(str(path))
+    meta, _ = tgm_file[0]
+    anemoi = meta.base[2]["anemoi"]
+    assert anemoi["param"] == "t"
+    assert anemoi["levtype"] == "pl"
+    assert anemoi["level"] == 500
+
+
+def test_remote_write_via_memory_fs():
+    """Write to fsspec memory filesystem and read back valid tensogram messages."""
+    import fsspec
+
+    url = "memory://test_forecast.tgm"
+    context = _make_context()
+    output = TensogramOutput(context, url)
+
+    states = [_make_state(h) for h in range(1, 3)]
+    output.open(states[0])
+    for state in states:
+        output.write_step(state)
+    output.close()
+
+    # Read back raw bytes via fsspec memory fs and scan as tensogram messages.
+    fs = fsspec.filesystem("memory")
+    raw = fs.open(url, "rb").read()
+
+    messages = tensogram.scan(raw)
+    assert len(messages) == 2
+
+    for i, (offset, length) in enumerate(messages):
+        msg_bytes = raw[offset : offset + length]
+        meta, objects = tensogram.decode(msg_bytes)
+        assert len(objects) == 5  # lat, lon, 3 fields
+        assert meta.extra["anemoi"]["step"] == states[i]["step"].total_seconds()
+
+
+def test_dtype_float64(tmp_path):
+    """dtype=float64 stores field arrays as float64."""
+    path = tmp_path / "f64.tgm"
+    context = _make_context(["2t"])
+    output = TensogramOutput(context, str(path), dtype="float64")
+
+    state = _make_state(field_names=["2t"])
+    output.open(state)
+    output.write_step(state)
+    output.close()
+
+    tgm_file = tensogram.TensogramFile.open(str(path))
+    meta, objects = tgm_file[0]
+    desc, arr = objects[2]
+    assert desc.dtype == "float64"
+    assert arr.dtype == np.float64
+
+
+def test_close_is_idempotent(tmp_path):
+    """close() can be called multiple times without error."""
+    path = tmp_path / "idem.tgm"
+    context = _make_context()
+    output = TensogramOutput(context, str(path))
+    output.open(_make_state())
+    output.write_step(_make_state())
+    output.close()
+    output.close()  # should not raise
+
+
+def test_dim_names_in_metadata(tmp_path):
+    """dim_names hint is written into _extra_[dim_names] and readable by xarray."""
+    xr = pytest.importorskip("xarray", reason="xarray not installed")
+    pytest.importorskip("tensogram_xarray", reason="tensogram_xarray not installed")
+
+    path = tmp_path / "dimnames.tgm"
+    context = _make_context()
+    output = TensogramOutput(context, str(path))
+    state = _make_state()
+    output.open(state)
+    output.write_step(state)
+    output.close()
+
+    tgm_file = tensogram.TensogramFile.open(str(path))
+    meta, _ = tgm_file[0]
+    dim_names = meta.extra["dim_names"]
+    assert str(N_GRID) in dim_names
+    assert dim_names[str(N_GRID)] == "values"
+
+    ds = xr.open_dataset(str(path), engine="tensogram")
+    assert "values" in ds.dims
+    assert ds["2t"].dims == ("values",)
+
+
+def test_stacked_dim_names_in_xarray(tmp_path):
+    """Stacked fields get (values, level) dims when opened in xarray."""
+    xr = pytest.importorskip("xarray", reason="xarray not installed")
+    pytest.importorskip("tensogram_xarray", reason="tensogram_xarray not installed")
+
+    path = tmp_path / "stacked_dims.tgm"
+    context = _make_pl_context(params=["t"], levels=[500, 850, 1000])
+    output = TensogramOutput(context, str(path), stack_pressure_levels=True)
+    state = _make_pl_state(params=["t"], levels=[500, 850, 1000])
+    output.open(state)
+    output.write_step(state)
+    output.close()
+
+    ds = xr.open_dataset(str(path), engine="tensogram")
+    assert "values" in ds.dims
+    assert "level" in ds.dims
+    assert ds["t"].dims == ("values", "level")
+    assert ds["t"].shape == (N_GRID, 3)
+
+
+# ---------------------------------------------------------------------------
+# Pressure-level stacking tests
+# ---------------------------------------------------------------------------
+
+PL_LEVELS = [500, 850, 1000]
+PL_PARAMS = ["t", "u"]
+
+
+def _make_pl_context(params=PL_PARAMS, levels=PL_LEVELS, extra_fields=None):
+    """Context with pressure-level variables plus optional non-PL extras."""
+    typed_variables = {}
+    for param in params:
+        for level in levels:
+            name = f"{param}{level}"
+            typed_variables[name] = _make_variable(param=param, levtype="pl", level=level)
+    for name in extra_fields or []:
+        typed_variables[name] = _make_variable(param=name)
+
+    checkpoint = SimpleNamespace(typed_variables=typed_variables)
+    return SimpleNamespace(
+        checkpoint=checkpoint,
+        reference_date=datetime(2024, 1, 1),
+        write_initial_state=False,
+        output_frequency=None,
+        typed_variables={},
+    )
+
+
+def _make_pl_state(params=PL_PARAMS, levels=PL_LEVELS, extra_fields=None, n_grid=N_GRID, seed=0):
+    rng = np.random.default_rng(seed)
+    fields = {}
+    for param in params:
+        for level in levels:
+            fields[f"{param}{level}"] = rng.random(n_grid).astype(np.float32)
+    for name in extra_fields or []:
+        fields[name] = rng.random(n_grid).astype(np.float32)
+    return {
+        "date": datetime(2024, 1, 1, 1),
+        "step": timedelta(hours=1),
+        "latitudes": np.linspace(-90, 90, n_grid, dtype=np.float64),
+        "longitudes": np.linspace(0, 360, n_grid, dtype=np.float64),
+        "fields": fields,
+    }
+
+
+def test_stack_object_count(tmp_path):
+    """With stacking: one object per param, not per level."""
+    path = tmp_path / "stacked.tgm"
+    context = _make_pl_context()
+    output = TensogramOutput(context, str(path), stack_pressure_levels=True)
+
+    state = _make_pl_state()
+    output.open(state)
+    output.write_step(state)
+    output.close()
+
+    tgm_file = tensogram.TensogramFile.open(str(path))
+    meta, objects = tgm_file[0]
+
+    # lat + lon + 1 object per param (t, u)
+    assert len(objects) == 2 + len(PL_PARAMS)
+
+
+def test_stack_shape(tmp_path):
+    """Stacked objects have shape (n_levels, n_grid)."""
+    path = tmp_path / "stacked.tgm"
+    context = _make_pl_context()
+    output = TensogramOutput(context, str(path), stack_pressure_levels=True)
+
+    state = _make_pl_state()
+    output.open(state)
+    output.write_step(state)
+    output.close()
+
+    tgm_file = tensogram.TensogramFile.open(str(path))
+    meta, objects = tgm_file[0]
+
+    for obj_idx in range(2, 2 + len(PL_PARAMS)):
+        desc, arr = objects[obj_idx]
+        assert arr.shape == (N_GRID, len(PL_LEVELS)), f"expected ({N_GRID}, {len(PL_LEVELS)}), got {arr.shape}"
+
+
+def test_stack_levels_metadata(tmp_path):
+    """Stacked objects store 'levels' (plural) sorted ascending; no scalar 'level'."""
+    path = tmp_path / "stacked.tgm"
+    context = _make_pl_context()
+    output = TensogramOutput(context, str(path), stack_pressure_levels=True)
+
+    state = _make_pl_state()
+    output.open(state)
+    output.write_step(state)
+    output.close()
+
+    tgm_file = tensogram.TensogramFile.open(str(path))
+    meta, _ = tgm_file[0]
+
+    for obj_idx in range(2, 2 + len(PL_PARAMS)):
+        entry = meta.base[obj_idx]
+        anemoi = entry["anemoi"]
+        assert "levels" in anemoi, "stacked objects must have 'levels' key"
+        assert "level" not in anemoi, "stacked objects must not have scalar 'level'"
+        assert anemoi["levels"] == sorted(PL_LEVELS)
+        assert anemoi["levtype"] == "pl"
+        # "name" top-level for xarray backend
+        assert "name" in entry
+        assert entry["name"] == anemoi["param"]
+
+
+def test_stack_values_round_trip(tmp_path):
+    """Stacked values decode to the same data as the input, in level-sorted order."""
+    path = tmp_path / "stacked.tgm"
+    context = _make_pl_context(params=["t"], levels=[850, 500, 1000])  # unsorted input
+    output = TensogramOutput(context, str(path), stack_pressure_levels=True)
+
+    rng = np.random.default_rng(7)
+    fields = {f"t{lv}": rng.random(N_GRID).astype(np.float32) for lv in [850, 500, 1000]}
+    state = {
+        "date": datetime(2024, 1, 1, 1),
+        "step": timedelta(hours=1),
+        "latitudes": np.linspace(-90, 90, N_GRID, dtype=np.float64),
+        "longitudes": np.linspace(0, 360, N_GRID, dtype=np.float64),
+        "fields": fields,
+    }
+
+    output.open(state)
+    output.write_step(state)
+    output.close()
+
+    tgm_file = tensogram.TensogramFile.open(str(path))
+    meta, objects = tgm_file[0]
+
+    anemoi = meta.base[2]["anemoi"]
+    assert anemoi["levels"] == [500, 850, 1000]  # sorted ascending
+
+    _, arr = objects[2]
+    # shape is (n_grid, n_levels); columns are levels sorted ascending [500, 850, 1000]
+    np.testing.assert_allclose(arr[:, 0], fields["t500"], rtol=1e-6)
+    np.testing.assert_allclose(arr[:, 1], fields["t850"], rtol=1e-6)
+    np.testing.assert_allclose(arr[:, 2], fields["t1000"], rtol=1e-6)
+
+
+def test_stack_non_pl_fields_written_flat(tmp_path):
+    """Non-PL fields are written as individual objects even with stacking enabled."""
+    path = tmp_path / "mixed.tgm"
+    context = _make_pl_context(params=["t"], levels=[500, 850], extra_fields=["2t"])
+    output = TensogramOutput(context, str(path), stack_pressure_levels=True)
+
+    state = _make_pl_state(params=["t"], levels=[500, 850], extra_fields=["2t"])
+    output.open(state)
+    output.write_step(state)
+    output.close()
+
+    tgm_file = tensogram.TensogramFile.open(str(path))
+    meta, objects = tgm_file[0]
+
+    # lat + lon + 1 stacked t + 1 flat 2t = 4
+    assert len(objects) == 4
+
+    # Verify 2t is a 1-D flat field with scalar level metadata (no "levels" key)
+    flat_entries = [
+        meta.base[i]["anemoi"] for i in range(2, len(objects)) if meta.base[i]["anemoi"].get("variable") == "2t"
+    ]
+    assert len(flat_entries) == 1
+    assert "levels" not in flat_entries[0]
+    assert "level" not in flat_entries[0]
+
+
+def test_no_stack_level_metadata_correct(tmp_path):
+    """Without stacking, each PL field stores scalar 'level' and 'levtype'."""
+    path = tmp_path / "flat_pl.tgm"
+    context = _make_pl_context(params=["t"], levels=[500, 850])
+    output = TensogramOutput(context, str(path), stack_pressure_levels=False)
+
+    state = _make_pl_state(params=["t"], levels=[500, 850])
+    output.open(state)
+    output.write_step(state)
+    output.close()
+
+    tgm_file = tensogram.TensogramFile.open(str(path))
+    meta, objects = tgm_file[0]
+
+    # lat + lon + 2 individual fields
+    assert len(objects) == 4
+
+    for obj_idx in range(2, 4):
+        anemoi = meta.base[obj_idx]["anemoi"]
+        assert "level" in anemoi
+        assert "levtype" in anemoi
+        assert anemoi["levtype"] == "pl"
+        assert anemoi["param"] == "t"
+        assert "levels" not in anemoi  # no plural key in flat mode

--- a/tests/unit/test_tensogram_output.py
+++ b/tests/unit/test_tensogram_output.py
@@ -77,6 +77,50 @@ def _make_state(step_hours=1, field_names=FIELD_NAMES, n_grid=N_GRID, seed=0):
 # ---------------------------------------------------------------------------
 
 
+def test_write_step_before_open_raises():
+    """write_step raises RuntimeError when called before open()."""
+    context = _make_context()
+    output = TensogramOutput(context, "/tmp/never.tgm")
+    with pytest.raises(RuntimeError, match="open"):
+        output.write_step(_make_state())
+
+
+def test_write_initial_state_reduces_multistep(tmp_path):
+    """write_initial_state reduces a multi-step field array to its last step."""
+    from unittest.mock import patch
+
+    path = tmp_path / "init.tgm"
+    # write_initial_state=True so the base class actually calls write_step.
+    context = _make_context(["2t"])
+    output = TensogramOutput(context, str(path), write_initial_state=True)
+
+    # Build a state where "2t" has shape (3, N_GRID) -- 3 input steps.
+    rng = np.random.default_rng(1)
+    multi_step_values = rng.random((3, N_GRID)).astype(np.float32)
+    state = {
+        "date": datetime(2024, 1, 1),
+        "step": timedelta(0),
+        "latitudes": np.linspace(-90, 90, N_GRID, dtype=np.float64),
+        "longitudes": np.linspace(0, 360, N_GRID, dtype=np.float64),
+        "fields": {"2t": multi_step_values},
+    }
+
+    written_states = []
+
+    def capture_write_step(s):
+        written_states.append(s)
+
+    output.open(state)
+    with patch.object(output, "write_step", side_effect=capture_write_step):
+        output.write_initial_state(state)
+    output.close()
+
+    assert written_states, "write_step was not called by write_initial_state"
+    written_field = written_states[0]["fields"]["2t"]
+    # reduce_state selects the last step along axis 0.
+    np.testing.assert_array_equal(written_field, multi_step_values[-1])
+
+
 def test_write_and_read_local(tmp_path):
     """Write 3 steps to a local .tgm file and verify round-trip."""
     path = tmp_path / "forecast.tgm"
@@ -383,7 +427,7 @@ def test_stack_object_count(tmp_path):
 
 
 def test_stack_shape(tmp_path):
-    """Stacked objects have shape (n_levels, n_grid)."""
+    """Stacked objects have shape (n_grid, n_levels) -- grid axis first."""
     path = tmp_path / "stacked.tgm"
     context = _make_pl_context()
     output = TensogramOutput(context, str(path), stack_pressure_levels=True)

--- a/tests/unit/test_tensogram_output.py
+++ b/tests/unit/test_tensogram_output.py
@@ -159,14 +159,17 @@ def test_write_and_read_local(tmp_path):
 
         # Field objects -- "name" top-level for xarray backend.
         expected_step = int(states[i]["step"].total_seconds() / 3600)
-        expected_base_dt = (states[i]["date"] - states[i]["step"]).isoformat()
+        base_dt = states[i]["date"] - states[i]["step"]
+        expected_date = base_dt.strftime("%Y%m%d")
+        expected_time = base_dt.strftime("%H%M")
         for j, name in enumerate(FIELD_NAMES):
             obj_idx = 2 + j
             assert meta.base[obj_idx]["name"] == name
             assert meta.base[obj_idx]["anemoi"]["variable"] == name
             assert meta.base[obj_idx]["mars"]["param"] == name
             assert meta.base[obj_idx]["mars"]["step"] == expected_step
-            assert meta.base[obj_idx]["mars"]["basedatetime"] == expected_base_dt
+            assert meta.base[obj_idx]["mars"]["date"] == expected_date
+            assert meta.base[obj_idx]["mars"]["time"] == expected_time
             _, field_arr = objects[obj_idx]
             np.testing.assert_allclose(field_arr, states[i]["fields"][name], rtol=1e-6)
 
@@ -267,7 +270,8 @@ def test_mars_metadata_forwarded(tmp_path):
     assert mars["levtype"] == "pl"
     assert mars["level"] == 500
     assert mars["step"] == 6
-    assert mars["basedatetime"] == datetime(2024, 1, 1, 0).isoformat()
+    assert mars["date"] == "20240101"
+    assert mars["time"] == "0000"
     # "anemoi" only carries the internal variable name
     assert meta.base[2]["anemoi"]["variable"] == "t500"
 
@@ -330,10 +334,7 @@ def test_close_is_idempotent(tmp_path):
 
 
 def test_dim_names_in_metadata(tmp_path):
-    """dim_names hint is written into _extra_[dim_names] and readable by xarray."""
-    xr = pytest.importorskip("xarray", reason="xarray not installed")
-    pytest.importorskip("tensogram_xarray", reason="tensogram_xarray not installed")
-
+    """dim_names hint is written into _extra_['dim_names'] for the xarray backend."""
     path = tmp_path / "dimnames.tgm"
     context = _make_context()
     output = TensogramOutput(context, str(path))
@@ -348,16 +349,9 @@ def test_dim_names_in_metadata(tmp_path):
     assert str(N_GRID) in dim_names
     assert dim_names[str(N_GRID)] == "values"
 
-    ds = xr.open_dataset(str(path), engine="tensogram")
-    assert "values" in ds.dims
-    assert ds["2t"].dims == ("values",)
 
-
-def test_stacked_dim_names_in_xarray(tmp_path):
-    """Stacked fields get (values, level) dims when opened in xarray."""
-    xr = pytest.importorskip("xarray", reason="xarray not installed")
-    pytest.importorskip("tensogram_xarray", reason="tensogram_xarray not installed")
-
+def test_stacked_dim_names_in_metadata(tmp_path):
+    """Stacked fields write both 'values' and 'level' hints into _extra_['dim_names']."""
     path = tmp_path / "stacked_dims.tgm"
     context = _make_pl_context(params=["t"], levels=[500, 850, 1000])
     output = TensogramOutput(context, str(path), stack_pressure_levels=True)
@@ -366,11 +360,13 @@ def test_stacked_dim_names_in_xarray(tmp_path):
     output.write_step(state)
     output.close()
 
-    ds = xr.open_dataset(str(path), engine="tensogram")
-    assert "values" in ds.dims
-    assert "level" in ds.dims
-    assert ds["t"].dims == ("values", "level")
-    assert ds["t"].shape == (N_GRID, 3)
+    tgm_file = tensogram.TensogramFile.open(str(path))
+    meta, _ = tgm_file[0]
+    dim_names = meta.extra["dim_names"]
+    assert str(N_GRID) in dim_names
+    assert dim_names[str(N_GRID)] == "values"
+    assert str(3) in dim_names
+    assert dim_names[str(3)] == "level"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_tensogram_output.py
+++ b/tests/unit/test_tensogram_output.py
@@ -176,6 +176,13 @@ def test_simple_packing_encoding(tmp_path):
     np.testing.assert_allclose(decoded, values, atol=0.002)
 
 
+def test_simple_packing_requires_bits(tmp_path):
+    """encoding='simple_packing' without bits raises ValueError immediately."""
+    context = _make_context(["2t"])
+    with pytest.raises(ValueError, match="bits must be set"):
+        TensogramOutput(context, str(tmp_path / "out.tgm"), encoding="simple_packing")
+
+
 def test_grib_metadata_forwarded(tmp_path):
     """level/levtype from grib_keys appear in per-object anemoi metadata."""
     path = tmp_path / "levs.tgm"

--- a/tests/unit/test_tensogram_output.py
+++ b/tests/unit/test_tensogram_output.py
@@ -158,11 +158,15 @@ def test_write_and_read_local(tmp_path):
         np.testing.assert_allclose(lon_arr, states[i]["longitudes"])
 
         # Field objects -- "name" top-level for xarray backend.
+        expected_step = int(states[i]["step"].total_seconds() / 3600)
+        expected_base_dt = (states[i]["date"] - states[i]["step"]).isoformat()
         for j, name in enumerate(FIELD_NAMES):
             obj_idx = 2 + j
             assert meta.base[obj_idx]["name"] == name
             assert meta.base[obj_idx]["anemoi"]["variable"] == name
-            assert meta.base[obj_idx]["anemoi"]["param"] == name
+            assert meta.base[obj_idx]["mars"]["param"] == name
+            assert meta.base[obj_idx]["mars"]["step"] == expected_step
+            assert meta.base[obj_idx]["mars"]["basedatetime"] == expected_base_dt
             _, field_arr = objects[obj_idx]
             np.testing.assert_allclose(field_arr, states[i]["fields"][name], rtol=1e-6)
 
@@ -227,8 +231,10 @@ def test_simple_packing_requires_bits(tmp_path):
         TensogramOutput(context, str(tmp_path / "out.tgm"), encoding="simple_packing")
 
 
-def test_grib_metadata_forwarded(tmp_path):
-    """level/levtype from grib_keys appear in per-object anemoi metadata."""
+def test_mars_metadata_forwarded(tmp_path):
+    """grib_keys appear in per-object 'mars' namespace, following tensogram-grib convention.
+    step and basedatetime are also written into mars.
+    """
     path = tmp_path / "levs.tgm"
     typed_variables = {
         "t500": _make_variable(param="t", levtype="pl", level=500),
@@ -244,8 +250,8 @@ def test_grib_metadata_forwarded(tmp_path):
 
     output = TensogramOutput(context, str(path))
     state = {
-        "date": datetime(2024, 1, 1, 1),
-        "step": timedelta(hours=1),
+        "date": datetime(2024, 1, 1, 6),
+        "step": timedelta(hours=6),
         "latitudes": np.zeros(10, dtype=np.float64),
         "longitudes": np.zeros(10, dtype=np.float64),
         "fields": {"t500": np.ones(10, dtype=np.float32)},
@@ -256,10 +262,14 @@ def test_grib_metadata_forwarded(tmp_path):
 
     tgm_file = tensogram.TensogramFile.open(str(path))
     meta, _ = tgm_file[0]
-    anemoi = meta.base[2]["anemoi"]
-    assert anemoi["param"] == "t"
-    assert anemoi["levtype"] == "pl"
-    assert anemoi["level"] == 500
+    mars = meta.base[2]["mars"]
+    assert mars["param"] == "t"
+    assert mars["levtype"] == "pl"
+    assert mars["level"] == 500
+    assert mars["step"] == 6
+    assert mars["basedatetime"] == datetime(2024, 1, 1, 0).isoformat()
+    # "anemoi" only carries the internal variable name
+    assert meta.base[2]["anemoi"]["variable"] == "t500"
 
 
 def test_remote_write_via_memory_fs():
@@ -462,13 +472,15 @@ def test_stack_levels_metadata(tmp_path):
     for obj_idx in range(2, 2 + len(PL_PARAMS)):
         entry = meta.base[obj_idx]
         anemoi = entry["anemoi"]
+        mars = entry["mars"]
         assert "levels" in anemoi, "stacked objects must have 'levels' key"
-        assert "level" not in anemoi, "stacked objects must not have scalar 'level'"
+        assert "level" not in anemoi, "stacked objects must not have scalar 'level' in anemoi"
+        assert "level" not in mars, "stacked objects must not have scalar 'level' in mars"
         assert anemoi["levels"] == sorted(PL_LEVELS)
-        assert anemoi["levtype"] == "pl"
-        # "name" top-level for xarray backend
+        assert mars["levtype"] == "pl"
+        # "name" top-level for xarray backend matches the param in mars
         assert "name" in entry
-        assert entry["name"] == anemoi["param"]
+        assert entry["name"] == mars["param"]
 
 
 def test_stack_values_round_trip(tmp_path):
@@ -548,9 +560,10 @@ def test_no_stack_level_metadata_correct(tmp_path):
     assert len(objects) == 4
 
     for obj_idx in range(2, 4):
+        mars = meta.base[obj_idx]["mars"]
         anemoi = meta.base[obj_idx]["anemoi"]
-        assert "level" in anemoi
-        assert "levtype" in anemoi
-        assert anemoi["levtype"] == "pl"
-        assert anemoi["param"] == "t"
+        assert "level" in mars
+        assert "levtype" in mars
+        assert mars["levtype"] == "pl"
+        assert mars["param"] == "t"
         assert "levels" not in anemoi  # no plural key in flat mode


### PR DESCRIPTION
## Summary

- Adds `TensogramOutput`, a new output plugin registered as `"tensogram"` that writes each forecast step as one tensogram message appended to a `.tgm` file
- Supports local paths and remote URLs (`s3://`, `gs://`, `az://`, ...) via fsspec with per-step streaming -- no full-forecast buffering
- Optional pressure-level stacking groups fields by `param` into `(n_grid, n_levels)` objects, sorted by level ascending

## Configuration

```yaml
output:
  tensogram:
    path: forecast.tgm
    encoding: none          # or simple_packing
    bits: 16                # bits per value for simple_packing
    compression: zstd       # zstd | lz4 | szip | blosc2 | none
    dtype: float32          # float32 | float64
    stack_pressure_levels: false
    variables: null         # null = all variables
```

## Message layout (one per step)

| Object | Content | `base[i]["name"]` |
|---|---|---|
| 0 | latitudes (float64) | `"grid_latitude"` |
| 1 | longitudes (float64) | `"grid_longitude"` |
| 2..N | field arrays | variable name |

`_extra_["anemoi"]` carries `date` and `step`. `_extra_["dim_names"]` carries `{"<n_grid>": "values"}` (and `{"<n_levels>": "level"}` when stacking) so the tensogram-xarray backend automatically names dimensions without requiring the reader to pass `dim_names` explicitly (requires ecmwf/tensogram#34).

## xarray result

```python
ds = xr.open_dataset("forecast.tgm", engine="tensogram")
# Dimensions: (values: 10944)
# Data variables: grid_latitude, grid_longitude, 2t, u10, ...
# With stacking: z (values, level)
```

## Dependencies

- Requires [ecmwf/tensogram#34](https://github.com/ecmwf/tensogram/pull/34) for automatic dimension naming in xarray
- `tensogram` and `fsspec` (fsspec is already a transitive dep via earthkit-data)

## Test plan

- [ ] 15 unit tests pass: `python -m pytest tests/unit/test_tensogram_output.py -v`
- [x] Round-trip local write/read
- [ ] Remote write via fsspec memory filesystem
- [ ] `simple_packing` encoding round-trip within quantisation tolerance
- [ ] Pressure-level stacking shape, metadata, and value ordering
- [ ] xarray dim names (`"values"`, `"level"`) resolved automatically