### PR TITLE
feat: allow using the filter's forward method in forward_transform_filter

### DIFF
--- a/docs/inference/configs/processors.rst
+++ b/docs/inference/configs/processors.rst
@@ -22,8 +22,7 @@ Replaces NaNs with the mean.
 forward_transform_filter
 ========================
 
-Applies a filter from `anemoi-transform
-<https://anemoi.readthedocs.io/projects/transform/en/latest/_api/transform.filters.html>`_.
+Applies a filter from :ref:`anemoi-transform <anemoi-transform:list-of-filters>`.
 
 Either the name of the filter can be provided as a string or a dictionary with the filter name as the key and the filter arguments as the value. For example:
 
@@ -119,15 +118,14 @@ To specify the fields to accumulate:
 backward_transform_filter
 =========================
 
-Applies a backward transform filter from `anemoi-transform
-<https://anemoi.readthedocs.io/projects/transform/en/latest/_api/transform.filters.html>`_.
+Applies a backward transform filter from :ref:`anemoi-transform <anemoi-transform:list-of-filters>`.
 
 forward_transform_filter
 =========================
 
-Applies a backward transform on the reversed filter from `anemoi-transform
-<https://anemoi.readthedocs.io/projects/transform/en/latest/_api/transform.filters.html>`_
-or applies the forward transform if `use_forward: true` is given.
+Applies a backward transform on the reversed filter from
+:ref:`anemoi-transform <anemoi-transform:list-of-filters>` or applies the forward
+transform if `use_forward: true` is given.
 
 For example to use regrid as a post-processor:
 

--- a/docs/inference/configs/processors.rst
+++ b/docs/inference/configs/processors.rst
@@ -122,6 +122,23 @@ backward_transform_filter
 Applies a backward transform filter from `anemoi-transform
 <https://anemoi.readthedocs.io/projects/transform/en/latest/_api/transform.filters.html>`_.
 
+forward_transform_filter
+=========================
+
+Applies a backward transform on the reversed filter from `anemoi-transform
+<https://anemoi.readthedocs.io/projects/transform/en/latest/_api/transform.filters.html>`_
+or applies the forward transform if `use_forward: true` is given.
+
+For example to use regrid as a post-processor:
+
+.. code:: yaml
+
+   post_processors:
+     - forward_transform_filter:
+         use_forward: true
+         filter: regrid
+         # ...
+
 Extractors and Masking
 ======================
 

--- a/docs/inference/configs/processors.rst
+++ b/docs/inference/configs/processors.rst
@@ -135,9 +135,9 @@ For example to use regrid as a post-processor:
 
    post_processors:
      - forward_transform_filter:
-         use_forward: true
-         filter: regrid
-         # ...
+         regrid:
+           use_forward: true
+           # other options for the filter
 
 Extractors and Masking
 ======================

--- a/src/anemoi/inference/post_processors/backward_transform_filter.py
+++ b/src/anemoi/inference/post_processors/backward_transform_filter.py
@@ -112,11 +112,68 @@ class BackwardTransformFilter(Processor):
 
 @post_processor_registry.register("forward_transform_filter")
 class ForwardTransformFilter(BackwardTransformFilter):
-    """Apply a transform forward as a post-processor."""
+    """Apply a transform forward or reversed backward as a post-processor."""
 
-    def __init__(self, *args, **kwargs: Any) -> None:
+    def __init__(self, *args: Any, use_forward: bool = False, **kwargs: Any) -> None:
+        """Initialize the ForwardTransformFilter.
+
+        Parameters
+        ----------
+        *args : Any
+            Positional arguments to pass to the parent's __init__.
+        use_forward : bool
+            Whether to use the forward method of the transform filter. If False, will
+            use the backward transform with the .reverse() method applied to the filter.
+            Defaults to False.
+        **kwargs : Any
+            Additional arguments to pass to the parent's __init__.
+        """
         super().__init__(*args, **kwargs)
-        self.filter = self.filter.reverse()
+
+        self.use_forward = use_forward
+
+        if not self.use_forward:
+            self.filter = self.filter.reverse()
+
+    def _process_forward(self, state: State) -> State:
+        """Process the given state using the forward transform filter.
+
+        Parameters
+        ----------
+        state : State
+            The state to be processed.
+
+        Returns
+        -------
+        State
+            The processed state.
+        """
+        if self.skip_initial_state and ("step" not in state or state["step"] == timedelta(0)):
+            return state
+
+        fields = self.filter.forward(wrap_state(state))
+
+        return unwrap_state(fields, state, namer=self.metadata.default_namer())
+
+    def process(self, state: State) -> State:
+        """Process the given state using the forward transform filter if use_forward=True,
+        otherwise uses the backward transform filter with the filter reversed.
+
+        Parameters
+        ----------
+        state : State
+            The state to be processed.
+
+        Returns
+        -------
+        State
+            The processed state.
+        """
+
+        if self.use_forward:
+            return self._process_forward(state)
+
+        return super().process(state)
 
     def __repr__(self) -> str:
         """Return a string representation of the ForwardTransformFilter object.
@@ -126,4 +183,4 @@ class ForwardTransformFilter(BackwardTransformFilter):
         str
             String representation of the object.
         """
-        return f"ForwardTransformFilter(filter={self.filter})"
+        return f"ForwardTransformFilter(filter={self.filter}, use_forward={self.use_forward})"

--- a/src/anemoi/inference/post_processors/backward_transform_filter.py
+++ b/src/anemoi/inference/post_processors/backward_transform_filter.py
@@ -13,6 +13,7 @@ from datetime import timedelta
 from typing import Any
 
 from anemoi.transform.filters import filter_registry
+from earthkit.data import FieldList
 
 from anemoi.inference.context import Context
 from anemoi.inference.decorators import main_argument
@@ -95,9 +96,12 @@ class BackwardTransformFilter(Processor):
         if self.skip_initial_state and ("step" not in state or state["step"] == timedelta(0)):
             return state
 
-        fields = self.filter.backward(wrap_state(state))
+        fields = self._exec_filter(wrap_state(state))
 
         return unwrap_state(fields, state, namer=self.metadata.default_namer())
+
+    def _exec_filter(self, state: FieldList) -> FieldList:
+        return self.filter.backward(state)
 
     def __repr__(self) -> str:
         """Return a string representation of the BackwardTransformFilter object.
@@ -135,45 +139,15 @@ class ForwardTransformFilter(BackwardTransformFilter):
         if not self.use_forward:
             self.filter = self.filter.reverse()
 
-    def _process_forward(self, state: State) -> State:
-        """Process the given state using the forward transform filter.
-
-        Parameters
-        ----------
-        state : State
-            The state to be processed.
-
-        Returns
-        -------
-        State
-            The processed state.
-        """
-        if self.skip_initial_state and ("step" not in state or state["step"] == timedelta(0)):
-            return state
-
-        fields = self.filter.forward(wrap_state(state))
-
-        return unwrap_state(fields, state, namer=self.metadata.default_namer())
-
-    def process(self, state: State) -> State:
+    def _exec_filter(self, state: FieldList) -> FieldList:
         """Process the given state using the forward transform filter if use_forward=True,
         otherwise uses the backward transform filter with the filter reversed.
-
-        Parameters
-        ----------
-        state : State
-            The state to be processed.
-
-        Returns
-        -------
-        State
-            The processed state.
         """
 
         if self.use_forward:
-            return self._process_forward(state)
+            return self.filter.forward(state)
 
-        return super().process(state)
+        return self.filter.backward(state)
 
     def __repr__(self) -> str:
         """Return a string representation of the ForwardTransformFilter object.


### PR DESCRIPTION
## Description

Currently the `forward_transform_filter` uses the backward method of a filter and applies a `.reverse()`. This adds the argument `use_forward` to allow using the forward method of the filter instead. This can be useful for filters like `regrid`. (see ecmwf/anemoi-transform#275).

## What problem does this change solve?
Some forward filters (like regrid) would be useful as post-processors but are not currently accessible as they don't implement a backward method.

## What issue or task does this change relate to?
Related to ecmwf/anemoi-transform#275

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)


<!-- readthedocs-preview anemoi-inference start -->
----
📚 Documentation preview 📚: https://anemoi-inference--491.org.readthedocs.build/en/491/

<!-- readthedocs-preview anemoi-inference end -->