### PR TITLE
fix(postprocessing): Excessive memory copying in postprocessing pipeline

### DIFF
--- a/src/anemoi/inference/post_processors/earthkit_state.py
+++ b/src/anemoi/inference/post_processors/earthkit_state.py
@@ -187,7 +187,7 @@ def unwrap_state(fields: ekd.FieldList, state: State, namer: Callable) -> State:
             new_fields[name] = n.to_numpy()
         else:
             new_fields[name] = n.to_numpy(flatten=True)
-    
+
     state = state.copy()
     state["fields"] = new_fields
 

--- a/src/anemoi/inference/post_processors/earthkit_state.py
+++ b/src/anemoi/inference/post_processors/earthkit_state.py
@@ -120,7 +120,7 @@ class StateField(ekd.Field):
         FloatArray
             The values of the field in the specified data type.
         """
-        return self.__values.astype(dtype)
+        return np.asarray(self.__values, dtype=dtype)
 
     @property
     def shape(self) -> Shape:
@@ -178,8 +178,16 @@ def unwrap_state(fields: ekd.FieldList, state: State, namer: Callable) -> State:
 
     for n in fields:
         name = namer(n, n.metadata())
-        new_fields[name] = n.to_numpy(flatten=True)
-
+        if isinstance(n, StateField):
+            # StateField values are already flat 1D numpy arrays.
+            # Use to_numpy() without flatten=True to avoid the always-copy
+            # behavior of ndarray.flatten(). Combined with np.asarray in
+            # _values(), this avoids unnecessary copies for pass-through
+            # fields that were not transformed.
+            new_fields[name] = n.to_numpy()
+        else:
+            new_fields[name] = n.to_numpy(flatten=True)
+    
     state = state.copy()
     state["fields"] = new_fields
 


### PR DESCRIPTION
Refactor to use np.asarray for value conversion and optimise to_numpy calls for StateField.

I am proposing a solution that is working for me now. Are there more elegant ways to avoid the OOM error?
But for sure, the current version seems to use too much memory.

## Description
Inference was failing for me because of OOM errors when using several post-processors:
```
slurmstepd: error: Detected 1 oom_kill event in StepId=31945079.0. 
Some of the step tasks have been OOM Killed.
srun: error: ac6-321: task 0: Out Of Memory
srun: Terminating StepId=31945079.0
```

## What problem does this change solve?
The OOM is caused by excessive memory copying in the post-processing pipeline. 
For each forecast step:

- BackwardTransformFilter instances run sequentially
- Each one calls wrap_state → filter.backward() → unwrap_state
- unwrap_state calls n.to_numpy(flatten=True) on ALL fields (not just the 2-3 that were transformed)
- StateField._values() uses .astype(dtype) which always copies, even when dtype matches
- flatten=True calls .flatten() which always copies again


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)

BEGIN_COMMIT_OVERRIDE
perf(post-processors): Excessive memory copying in post-processing pipeline (#493)
END_COMMIT_OVERRIDE
