### PR TITLE
refactor: Rename forcings inputs to providers

### DIFF
--- a/src/anemoi/inference/forcings.py
+++ b/src/anemoi/inference/forcings.py
@@ -33,7 +33,7 @@ LOG = logging.getLogger(__name__)
 
 
 class Forcings(ABC):
-    """Represents the forcings for the model."""
+    """Represents a forcings provider for the model."""
 
     mask: IntArray
     variables: list[str]

--- a/src/anemoi/inference/runner.py
+++ b/src/anemoi/inference/runner.py
@@ -238,20 +238,20 @@ class Runner(Context):
             finally:
                 self.complete_forecast_hook()
 
-    def initial_constant_forcings_inputs(self, constant_forcings_inputs: list[Forcings]) -> list[Forcings]:
-        """Modify the constant forcings inputs for the first step."""
+    def initial_constant_forcings_providers(self, constant_forcings_providers: list[Forcings]) -> list[Forcings]:
+        """Modify the constant forcings providers for the first step."""
         # Give an opportunity to modify the forcings for the first step
-        return constant_forcings_inputs
+        return constant_forcings_providers
 
-    def initial_dynamic_forcings_inputs(self, dynamic_forcings_inputs: list[Forcings]) -> list[Forcings]:
-        """Modify the dynamic forcings inputs for the initial step of the inference process.
+    def initial_dynamic_forcings_providers(self, dynamic_forcings_providers: list[Forcings]) -> list[Forcings]:
+        """Modify the dynamic forcings providers for the initial step of the inference process.
 
         This method provides a hook to adjust the list of dynamic forcings before the first
         inference step is executed. By default, it returns the inputs unchanged, but subclasses
         can override this method to implement custom preprocessing or initialization logic.
         """
         # Give an opportunity to modify the forcings for the first step
-        return dynamic_forcings_inputs
+        return dynamic_forcings_providers
 
     def prepare_output_state(
         self, output: Generator[dict[str, State], None, None], return_numpy: bool

--- a/src/anemoi/inference/runners/temporal_downscaler.py
+++ b/src/anemoi/inference/runners/temporal_downscaler.py
@@ -47,22 +47,26 @@ class TemporalDownscalerTensorHandler(TensorHandler):
         # TODO: Check for user provided forcings
 
         # We may need different forcings initial conditions
-        initial_constant_forcings_inputs = self.context.initial_constant_forcings_inputs(self.constant_forcings_inputs)
-        initial_dynamic_forcings_inputs = self.context.initial_dynamic_forcings_inputs(self.dynamic_forcings_inputs)
+        initial_constant_forcings_providers = self.context.initial_constant_forcings_providers(
+            self.constant_forcings_providers
+        )
+        initial_dynamic_forcings_providers = self.context.initial_dynamic_forcings_providers(
+            self.dynamic_forcings_providers
+        )
 
         LOG.info("-" * 80)
-        LOG.info("Initial forcings inputs:")
+        LOG.info("Initial forcings providers:")
         LOG.info("  Constant forcings:")
-        for f in initial_constant_forcings_inputs:
+        for f in initial_constant_forcings_providers:
             LOG.info(f"    {f}")
         LOG.info("  Dynamic forcings:")
-        for f in initial_dynamic_forcings_inputs:
+        for f in initial_dynamic_forcings_providers:
             LOG.info(f"    {f}")
         LOG.info("Initial forcings dates:")
         LOG.info(f"  {', '.join([date.isoformat() for date in dates])}")
         LOG.info("-" * 80)
 
-        for source in initial_constant_forcings_inputs:
+        for source in initial_constant_forcings_providers:
             arrays = source.load_forcings_array(reference_dates, input_state)
             for name, forcing in zip(source.variables, arrays):
                 assert isinstance(forcing, np.ndarray), (name, forcing)
@@ -71,7 +75,7 @@ class TemporalDownscalerTensorHandler(TensorHandler):
                 if self.trace:
                     self.trace.from_source(name, source, "initial constant forcings")
 
-        for source in initial_dynamic_forcings_inputs:
+        for source in initial_dynamic_forcings_providers:
             arrays = source.load_forcings_array(dates, input_state)
             for name, forcing in zip(source.variables, arrays):
                 assert isinstance(forcing, np.ndarray), (name, forcing)

--- a/src/anemoi/inference/tasks/runner.py
+++ b/src/anemoi/inference/tasks/runner.py
@@ -103,24 +103,24 @@ class CoupledRunner(Runner):
 
         return result
 
-    def initial_dynamic_forcings_inputs(self, dynamic_forcings_inputs: list[Forcings]) -> list[Forcings]:
-        """Modify the dynamic forcings inputs for the first step.
+    def initial_dynamic_forcings_providers(self, dynamic_forcings_providers: list[Forcings]) -> list[Forcings]:
+        """Modify the dynamic forcings providers for the first step.
 
         Parameters
         ----------
-        dynamic_forcings_inputs : list of Forcings
-            The dynamic forcings inputs.
+        dynamic_forcings_providers : list of Forcings
+            The dynamic forcings providers.
 
         Returns
         -------
         list[Forcings]
-            The modified dynamic forcings inputs.
+            The modified dynamic forcings providers.
         """
         # For the initial state we need to load the forcings
-        # from the default input.
+        # from the default provider.
 
         result = []
-        for f in dynamic_forcings_inputs:
+        for f in dynamic_forcings_providers:
             if isinstance(f, CoupledForcings):
                 result.extend(super().create_dynamic_coupled_forcings(f.variables, f.mask))
             else:

--- a/src/anemoi/inference/tensors.py
+++ b/src/anemoi/inference/tensors.py
@@ -79,21 +79,21 @@ class TensorHandler:
         self._output_kinds = {}
         self._output_tensor_by_name = []
 
-        self.constant_forcings_inputs = self.create_constant_forcings_inputs()
-        self.dynamic_forcings_inputs = self.create_dynamic_forcings_inputs()
-        self.boundary_forcings_inputs = self.create_boundary_forcings_inputs()
+        self.constant_forcings_providers = self.create_constant_forcings_providers()
+        self.dynamic_forcings_providers = self.create_dynamic_forcings_providers()
+        self.boundary_forcings_providers = self.create_boundary_forcings_providers()
 
         LOG.info("-" * 80)
-        LOG.info("Constant forcings inputs:")
-        for f in self.constant_forcings_inputs:
+        LOG.info("Constant forcings providers:")
+        for f in self.constant_forcings_providers:
             LOG.info(f"  {f}")
 
-        LOG.info("Dynamic forcings inputs:")
-        for f in self.dynamic_forcings_inputs:
+        LOG.info("Dynamic forcings providers:")
+        for f in self.dynamic_forcings_providers:
             LOG.info(f"  {f}")
 
-        LOG.info("Boundary forcings inputs:")
-        for f in self.boundary_forcings_inputs:
+        LOG.info("Boundary forcings providers:")
+        for f in self.boundary_forcings_providers:
             LOG.info(f"  {f}")
         LOG.info("-" * 80)
 
@@ -251,22 +251,26 @@ class TensorHandler:
         dates = [date + h for h in self.metadata.lagged]
 
         # TODO: Check for user provided forcings
-        initial_constant_forcings_inputs = self.context.initial_constant_forcings_inputs(self.constant_forcings_inputs)
-        initial_dynamic_forcings_inputs = self.context.initial_dynamic_forcings_inputs(self.dynamic_forcings_inputs)
+        initial_constant_forcings_providers = self.context.initial_constant_forcings_providers(
+            self.constant_forcings_providers
+        )
+        initial_dynamic_forcings_providers = self.context.initial_dynamic_forcings_providers(
+            self.dynamic_forcings_providers
+        )
 
         LOG.info("-" * 80)
-        LOG.info("Initial forcings inputs:")
+        LOG.info("Initial forcings providers:")
         LOG.info("  Constant forcings:")
-        for f in initial_constant_forcings_inputs:
+        for f in initial_constant_forcings_providers:
             LOG.info(f"    {f}")
         LOG.info("  Dynamic forcings:")
-        for f in initial_dynamic_forcings_inputs:
+        for f in initial_dynamic_forcings_providers:
             LOG.info(f"    {f}")
         LOG.info("Initial forcings dates:")
         LOG.info(f"  {', '.join([date.isoformat() for date in dates])}")
         LOG.info("-" * 80)
 
-        for source in initial_constant_forcings_inputs:
+        for source in initial_constant_forcings_providers:
             arrays = source.load_forcings_array(dates, input_state)
             for name, forcing in zip(source.variables, arrays):
                 assert isinstance(forcing, np.ndarray), (name, forcing)
@@ -275,7 +279,7 @@ class TensorHandler:
                 if self.trace:
                     self.trace.from_source(name, source, "initial constant forcings")
 
-        for source in initial_dynamic_forcings_inputs:
+        for source in initial_dynamic_forcings_providers:
             arrays = source.load_forcings_array(dates, input_state)
             for name, forcing in zip(source.variables, arrays):
                 assert isinstance(forcing, np.ndarray), (name, forcing)
@@ -284,7 +288,7 @@ class TensorHandler:
                 if self.trace:
                     self.trace.from_source(name, source, "initial dynamic forcings")
 
-    def create_constant_forcings_inputs(self) -> list["Forcings"]:
+    def create_constant_forcings_providers(self) -> list["Forcings"]:
         result = []
 
         loaded_variables, loaded_variables_mask = self.metadata.select_variables_and_masks(
@@ -313,7 +317,7 @@ class TensorHandler:
 
         return result
 
-    def create_dynamic_forcings_inputs(self) -> list["Forcings"]:
+    def create_dynamic_forcings_providers(self) -> list["Forcings"]:
         result = []
 
         loaded_variables, loaded_variables_mask = self.metadata.select_variables_and_masks(
@@ -341,7 +345,7 @@ class TensorHandler:
             )
         return result
 
-    def create_boundary_forcings_inputs(self) -> list["BoundaryForcings"]:
+    def create_boundary_forcings_providers(self) -> list["BoundaryForcings"]:
         if not self.metadata.has_supporting_array("output_mask"):
             return []
 
@@ -419,7 +423,7 @@ class TensorHandler:
         # input_tensor_torch is shape: (batch, multi_step_input, values, variables)
         # batch is always 1
 
-        for source in self.dynamic_forcings_inputs:
+        for source in self.dynamic_forcings_providers:
             forcings = source.load_forcings_array(dates, state)  # shape: (variables, dates, values)
 
             forcings = np.swapaxes(forcings, 0, 1)  # shape: (dates, variable, values)
@@ -456,7 +460,7 @@ class TensorHandler:
     ) -> "torch.Tensor":
         # input_tensor_torch is shape: (batch, multi_step_input, values, variables)
         # batch is always 1
-        sources = self.boundary_forcings_inputs
+        sources = self.boundary_forcings_providers
         for source in sources:
             forcings = source.load_forcings_array(dates, state)  # shape: (variables, dates, values)
 

--- a/tests/unit/test_forecast.py
+++ b/tests/unit/test_forecast.py
@@ -123,7 +123,7 @@ def forecast_runner_factory():
                 )
                 return np.broadcast_to(values[np.newaxis, :, np.newaxis], (1, n_dates, 2)).copy()
 
-        tensor_handler.dynamic_forcings_inputs = [GeometricDynamicForcer()]
+        tensor_handler.dynamic_forcings_providers = [GeometricDynamicForcer()]
 
         class SequentialBoundaryForcer:
             spatial_mask = ~metadata.output_mask
@@ -139,7 +139,7 @@ def forecast_runner_factory():
                 )
                 return np.broadcast_to(values[np.newaxis, :, np.newaxis], (1, n_dates, 1)).copy()
 
-        tensor_handler.boundary_forcings_inputs = [SequentialBoundaryForcer()]
+        tensor_handler.boundary_forcings_providers = [SequentialBoundaryForcer()]
 
         runner.tensor_handlers = dict(data=tensor_handler)
         return runner


### PR DESCRIPTION
## Description
The term "forcings input(s)" was too overloaded: it could refer to the input object loading the forcings from disk (e.g.: grib input), or the Forcings class that produces the forcing array.

Rename the latter to "forcings providers" to avoid confusion. 

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
