### PR TITLE
perf(forcings): Skip loading of initial forcings already in input state

### DIFF
--- a/src/anemoi/inference/forcings.py
+++ b/src/anemoi/inference/forcings.py
@@ -234,36 +234,6 @@ class CoupledForcings(Forcings):
         )
 
 
-class ConstantDateForcings(CoupledForcings):
-    """Retrieve forcings from the first date in the input. Used, for example, in the temporal downscaler where forcings are only available at the first time step of the input forecast."""
-
-    def load_forcings_array(self, dates: list[Date], current_state: State) -> FloatArray:
-        """Load the forcings for the given dates.
-
-        Parameters
-        ----------
-        dates : List[Any]
-            The list of dates for which to load the forcings.
-        current_state : State
-            The current state of the model.
-
-        Returns
-        -------
-        FloatArray
-            The loaded forcings as a numpy array.
-        """
-        constant_arr = self._state_to_numpy(
-            self.input.load_forcings_state(
-                dates=[dates[0]],
-                current_state=current_state,
-            ),
-            self.variables,
-            [dates[0]],
-        )
-
-        return np.concatenate([constant_arr for _ in range(len(dates))], axis=1)
-
-
 class ConstantForcings(CoupledForcings):
     # Just to have a different __repr__
     pass

--- a/src/anemoi/inference/runners/temporal_downscaler.py
+++ b/src/anemoi/inference/runners/temporal_downscaler.py
@@ -17,76 +17,17 @@ from anemoi.utils.dates import frequency_to_timedelta as to_timedelta
 from anemoi.utils.timer import Timer
 
 from anemoi.inference.config.run import RunConfiguration
-from anemoi.inference.forcings import ConstantDateForcings
-from anemoi.inference.forcings import Forcings
 from anemoi.inference.lazy import torch
 from anemoi.inference.metadata import Metadata
 from anemoi.inference.profiler import ProfilingLabel
 from anemoi.inference.runner import Runner
 from anemoi.inference.runner import RunnerClasses
-from anemoi.inference.tensors import Kind
-from anemoi.inference.tensors import TensorHandler
 from anemoi.inference.types import FloatArray
-from anemoi.inference.types import IntArray
 from anemoi.inference.types import State
 
 from . import runner_registry
 
 LOG = logging.getLogger(__name__)
-
-
-class TemporalDownscalerTensorHandler(TensorHandler):
-    def add_initial_forcings_to_input_state(self, input_state: State) -> None:
-        date = input_state["date"]
-        fields = input_state["fields"]
-
-        dates = [date + h for h in self.metadata.lagged]
-        reference_date = self.context.reference_date or date
-        reference_dates = [reference_date + h for h in self.metadata.lagged]
-
-        # TODO: Check for user provided forcings
-
-        # We may need different forcings initial conditions
-        initial_constant_forcings_providers = self.context.initial_constant_forcings_providers(
-            self.constant_forcings_providers
-        )
-        initial_dynamic_forcings_providers = self.context.initial_dynamic_forcings_providers(
-            self.dynamic_forcings_providers
-        )
-
-        LOG.info("-" * 80)
-        LOG.info("Initial forcings providers:")
-        LOG.info("  Constant forcings:")
-        for f in initial_constant_forcings_providers:
-            LOG.info(f"    {f}")
-        LOG.info("  Dynamic forcings:")
-        for f in initial_dynamic_forcings_providers:
-            LOG.info(f"    {f}")
-        LOG.info("Initial forcings dates:")
-        LOG.info(f"  {', '.join([date.isoformat() for date in dates])}")
-        LOG.info("-" * 80)
-
-        for source in initial_constant_forcings_providers:
-            arrays = source.load_forcings_array(reference_dates, input_state)
-            for name, forcing in zip(source.variables, arrays):
-                assert isinstance(forcing, np.ndarray), (name, forcing)
-                fields[name] = forcing
-                self._input_kinds[name] = Kind(forcing=True, constant=True, **source.kinds)
-                if self.trace:
-                    self.trace.from_source(name, source, "initial constant forcings")
-
-        for source in initial_dynamic_forcings_providers:
-            arrays = source.load_forcings_array(dates, input_state)
-            for name, forcing in zip(source.variables, arrays):
-                assert isinstance(forcing, np.ndarray), (name, forcing)
-                fields[name] = forcing
-                self._input_kinds[name] = Kind(forcing=True, constant=False, **source.kinds)
-                if self.trace:
-                    self.trace.from_source(name, source, "initial dynamic forcings")
-
-    def create_constant_coupled_forcings(self, variables: list[str], mask: IntArray) -> list[Forcings]:
-        result = ConstantDateForcings(self, self.constant_forcings_input, variables, mask)
-        return [result]
 
 
 class TemporalDownscalerMetadata(Metadata):
@@ -113,7 +54,6 @@ class TemporalDownscalerMultiOutRunner(Runner):
         super().__init__(
             config,
             classes=RunnerClasses(
-                tensor_handler=TemporalDownscalerTensorHandler,
                 metadata=TemporalDownscalerMetadata,
             ),
         )
@@ -122,6 +62,11 @@ class TemporalDownscalerMultiOutRunner(Runner):
             "Temporal downscaler runner requires exactly two input explicit times (t and t+temporal_downscaling_window), "
             f"but got {self.checkpoint.input_explicit_times}"
         )
+
+        self.temporal_downscaling_window = to_timedelta(self.checkpoint.data_frequency) * (
+            self.checkpoint.input_explicit_times[1] - self.checkpoint.input_explicit_times[0]
+        )
+
         assert len(self.checkpoint.target_explicit_times) in (
             self.checkpoint.input_explicit_times[1] - self.checkpoint.input_explicit_times[0] - 1,
             self.checkpoint.input_explicit_times[1] - self.checkpoint.input_explicit_times[0],
@@ -132,9 +77,6 @@ class TemporalDownscalerMultiOutRunner(Runner):
             f"input explicit times {self.checkpoint.input_explicit_times}"
         )
 
-        self.temporal_downscaling_window = to_timedelta(self.checkpoint.data_frequency) * (
-            self.checkpoint.input_explicit_times[1] - self.checkpoint.input_explicit_times[0]
-        )
         self.lead_time = to_timedelta(self.config.lead_time)
         self.time_step = self.temporal_downscaling_window
 

--- a/src/anemoi/inference/tensors.py
+++ b/src/anemoi/inference/tensors.py
@@ -250,7 +250,6 @@ class TensorHandler:
 
         dates = [date + h for h in self.metadata.lagged]
 
-        # TODO: Check for user provided forcings
         initial_constant_forcings_providers = self.context.initial_constant_forcings_providers(
             self.constant_forcings_providers
         )
@@ -268,25 +267,38 @@ class TensorHandler:
             LOG.info(f"    {f}")
         LOG.info("Initial forcings dates:")
         LOG.info(f"  {', '.join([date.isoformat() for date in dates])}")
+
+        for provider in initial_constant_forcings_providers:
+            if all(
+                name in fields and isinstance(fields[name], np.ndarray) and fields[name].size > 0
+                for name in provider.variables
+            ):
+                LOG.info(f"Skipping initial constant forcings {provider}, all variables are present in the input state")
+                continue
+            arrays = provider.load_forcings_array(dates, input_state)
+            for name, forcing in zip(provider.variables, arrays):
+                assert isinstance(forcing, np.ndarray), (name, forcing)
+                fields[name] = forcing
+                self._input_kinds[name] = Kind(forcing=True, constant=True, **provider.kinds)
+                if self.trace:
+                    self.trace.from_source(name, provider, "initial constant forcings")
+
+        for provider in initial_dynamic_forcings_providers:
+            if all(
+                name in fields and isinstance(fields[name], np.ndarray) and fields[name].size > 0
+                for name in provider.variables
+            ):
+                LOG.info(f"Skipping initial dynamic forcings {provider}, all variables are present in the input state")
+                continue
+            arrays = provider.load_forcings_array(dates, input_state)
+            for name, forcing in zip(provider.variables, arrays):
+                assert isinstance(forcing, np.ndarray), (name, forcing)
+                fields[name] = forcing
+                self._input_kinds[name] = Kind(forcing=True, constant=False, **provider.kinds)
+                if self.trace:
+                    self.trace.from_source(name, provider, "initial dynamic forcings")
+
         LOG.info("-" * 80)
-
-        for source in initial_constant_forcings_providers:
-            arrays = source.load_forcings_array(dates, input_state)
-            for name, forcing in zip(source.variables, arrays):
-                assert isinstance(forcing, np.ndarray), (name, forcing)
-                fields[name] = forcing
-                self._input_kinds[name] = Kind(forcing=True, constant=True, **source.kinds)
-                if self.trace:
-                    self.trace.from_source(name, source, "initial constant forcings")
-
-        for source in initial_dynamic_forcings_providers:
-            arrays = source.load_forcings_array(dates, input_state)
-            for name, forcing in zip(source.variables, arrays):
-                assert isinstance(forcing, np.ndarray), (name, forcing)
-                fields[name] = forcing
-                self._input_kinds[name] = Kind(forcing=True, constant=False, **source.kinds)
-                if self.trace:
-                    self.trace.from_source(name, source, "initial dynamic forcings")
 
     def create_constant_forcings_providers(self) -> list["Forcings"]:
         result = []


### PR DESCRIPTION
## Description
We've had a long standing issue of loading the initial forcings twice: once when we create the input state from the input objects, and then again in the subroutine `add_initial_forcings_to_input_state()` where we ask the forcing providers to load their forcings into the input state. 

This subroutine exists because of coupling: the coupled runner may need to inject different initial forcings. But there is no reason to be loading initial forcings that were already loaded by the input(s), even in a coupled scenario (at least currently there is no use-case to do so). So we can skip these entirely.

The performance improvement is marginal, but the nice side effect is that it simplifies the temporal downscaler: the custom tensorhandler is no longer needed because that only existed to deal with the initial constant forcings. Constant forcings will now automatically be loaded only once in the first input state and carried forward throughout the run. 

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
