### PR TITLE
perf(ekd): Select datetime before cloning fields

### DIFF
--- a/src/anemoi/inference/inputs/ekd.py
+++ b/src/anemoi/inference/inputs/ekd.py
@@ -18,7 +18,6 @@ from typing import Any
 
 import earthkit.data as ekd
 import numpy as np
-from earthkit.data.indexing.fieldlist import FieldArray
 from earthkit.data.utils.dates import to_datetime
 from numpy.typing import DTypeLike
 
@@ -36,13 +35,13 @@ from ..input import Input
 LOG = logging.getLogger(__name__)
 
 
-def find_variable(data: Any, name: str, namer: callable, **kwargs: Any) -> Any:
-    """Find a variable in an earthkit FieldList/FieldArray.
+def find_variable(data: ekd.FieldList, name: str, namer: callable, **kwargs: Any) -> ekd.FieldList:
+    """Find a variable in an earthkit FieldList.
 
     Parameters
     ----------
-    data : Any
-        The data to search (FieldList or FieldArray).
+    data : ekd.FieldList
+        The data to search.
     name : str
         The name of the variable to find.
     namer: callable
@@ -52,14 +51,14 @@ def find_variable(data: Any, name: str, namer: callable, **kwargs: Any) -> Any:
 
     Returns
     -------
-    Any
-        The selected variable (FieldArray subset).
+    ekd.FieldList
+        The selected variable (FieldList subset).
     """
 
     def _name(field: Any, _: Any, original_metadata: dict[str, Any]) -> str:
         return namer(field, original_metadata)
 
-    data = FieldArray([f.clone(name=_name) for f in data])
+    data = ekd.SimpleFieldList([f.clone(name=_name) for f in data])
     return data.sel(name=name, **kwargs)
 
 
@@ -79,12 +78,12 @@ class RulesNamer:
         self.rules = rules
         self.default_namer = default_namer
 
-    def __call__(self, field: Any, original_metadata: dict[str, Any]) -> str:
+    def __call__(self, field: ekd.Field, original_metadata: dict[str, Any]) -> str:
         """Generate a name for the field.
 
         Parameters
         ----------
-        field : Any
+        field : ekd.Field
             The field for which to generate a name.
         original_metadata : Dict[str, Any]
             The original metadata of the field.
@@ -105,14 +104,14 @@ class RulesNamer:
 
         return self.default_namer(field, original_metadata)
 
-    def substitute(self, template: str, field: Any, original_metadata: dict[str, Any]) -> str:
+    def substitute(self, template: str, field: ekd.Field, original_metadata: dict[str, Any]) -> str:
         """Substitute placeholders in the template with metadata values.
 
         Parameters
         ----------
         template : str
             The template string with placeholders.
-        field : Any
+        field : ekd.Field
             The field for which to generate a name.
         original_metadata : Dict[str, Any]
             The original metadata of the field.
@@ -161,15 +160,21 @@ class EkdInput(Input):
         assert callable(self._namer), type(self._namer)
 
     def _filter_and_sort(
-        self, data: Any, *, dates: list[Any], title: str, select_reference_date: bool = False, **kwargs
-    ) -> Any:
-        """Filter and sort the data (earthkit FieldList/FieldArray).
+        self,
+        data: ekd.FieldList,
+        *,
+        dates: list[Date],
+        title: str,
+        select_reference_date: bool = False,
+        **kwargs,
+    ) -> ekd.FieldList:
+        """Filter and sort the earthkit FieldList.
 
         Parameters
         ----------
-        data : Any
-            The data to filter and sort (FieldList or FieldArray).
-        dates : List[Any]
+        data : ekd.FieldList
+            The data to filter and sort.
+        dates : List[Date]
             The list of dates to select.
         title : str
             The title for logging.
@@ -181,45 +186,41 @@ class EkdInput(Input):
 
         Returns
         -------
-        Any
-            The filtered and sorted data (FieldArray).
+        ekd.FieldList
+            The filtered and sorted data.
         """
 
-        def _name(field: Any, _: Any, original_metadata: dict[str, Any]) -> str:
+        def _name(field: ekd.Field, _: Any, original_metadata: dict[str, Any]) -> str:
             return self._namer(field, original_metadata)
 
-        data = FieldArray([f.clone(name=_name) for f in data])
-
-        valid_datetime = [_.isoformat() for _ in dates]
-        LOG.info("Selecting fields %s %s", len(data), valid_datetime)
+        valid_datetime = [date.isoformat() for date in dates]
+        datetime_selection = dict(valid_datetime=valid_datetime)
 
         if select_reference_date:
-            data = data.sel(
-                name=self.variables,
-                valid_datetime=valid_datetime,
+            datetime_selection.update(
                 dataDate=int(self.reference_date.strftime("%Y%m%d")),
                 dataTime=int(self.reference_date.strftime("%H%M")),
-            ).order_by(
-                name=self.variables,
-                valid_datetime="ascending",
             )
-        else:
-            data = data.sel(name=self.variables, valid_datetime=valid_datetime).order_by(
-                name=self.variables,
-                valid_datetime="ascending",
-            )
+
+        data = ekd.SimpleFieldList([f.clone(name=_name) for f in data.sel(**datetime_selection)])
+        LOG.info("Selecting fields %s %s", len(data), valid_datetime)
+
+        data = data.sel(name=self.variables).order_by(
+            name=self.variables,
+            valid_datetime="ascending",
+        )
 
         check_data(title, data, self.variables, dates, self.metadata)
 
         return data
 
-    def _find_variable(self, data: Any, name: str, **kwargs: Any) -> Any:
-        """Find a variable in the data (earthkit FieldList/FieldArray selection).
+    def _find_variable(self, data: ekd.FieldList, name: str, **kwargs: Any) -> ekd.FieldList:
+        """Find a variable in the earthkit FieldList selection.
 
         Parameters
         ----------
-        data : Any
-            The data to search (FieldList or FieldArray).
+        data : ekd.FieldList
+            The data to search.
         name : str
             The name of the variable to find.
         **kwargs : Any
@@ -227,8 +228,8 @@ class EkdInput(Input):
 
         Returns
         -------
-        Any
-            The selected variable (FieldArray subset).
+        ekd.FieldList
+            The selected variable (FieldList subset).
         """
 
         return find_variable(data, name, self._namer, **kwargs)
@@ -249,7 +250,7 @@ class EkdInput(Input):
 
         Notes
         -----
-        - The `fields` argument must be an earthkit FieldList (or FieldArray-compatible).
+        - The `fields` argument must be an earthkit FieldList.
         - This method intentionally converts state["fields"] from a FieldList to
           a Dict[str, np.ndarray] with shape (len(dates), n_points).
         - Pre-processors are run while state["fields"] is still a FieldList.
@@ -466,7 +467,7 @@ class EkdInput(Input):
     def set_private_attributes(self, state: State, fields: ekd.FieldList) -> None:  # type: ignore
         """Set private attributes to the state.
 
-        Provides geography information if available retrieved from the fields (FieldList/FieldArray).
+        Provides geography information if available retrieved from the fields.
         """
         geography_information = {}
 


### PR DESCRIPTION
## Description
A small performance optimisation: when selecting variables in the ekd input, only clone the dates that we need instead of the whole fieldlist.

Impact is minimal in a forecast configuration, where the input fieldlist only contains a few steps.

But for the temporal downscaler, where the input fields can be a large forecast, this avoids unnecessary cloning of the whole fieldlist, resulting in a small speedup.

Also clean up some of the typings, and remove the old FieldArray in favour of the new FieldList and SimpleFieldList (to be further cleaned up in the 1.0 migration, but this is a first pass).

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
