### PR TITLE
feat: warn if patch_metadata adds new keys

### DIFF
--- a/src/anemoi/inference/checkpoint.py
+++ b/src/anemoi/inference/checkpoint.py
@@ -181,7 +181,16 @@ class Checkpoint:
             for dataset, metadata in multi_metadata.items():
                 patch = multi_datasets_config(self.patch_metadata, dataset, list(multi_metadata.keys()), strict=False)
                 LOG.warning(f"[{dataset}] Patching metadata with {patch}")
-                metadata.patch(patch)
+                new_keys = metadata.patch(patch)
+                if new_keys:
+                    LOG.warning(
+                        "[%s] The metadata patch created %d new key(s) that did not exist before: %s. "
+                        "This usually means the patch does not match this checkpoint's metadata schema, "
+                        "so the intended update was not applied.",
+                        dataset,
+                        len(new_keys),
+                        ", ".join(new_keys),
+                    )
 
         return multi_metadata
 

--- a/src/anemoi/inference/checkpoint.py
+++ b/src/anemoi/inference/checkpoint.py
@@ -184,9 +184,9 @@ class Checkpoint:
                 new_keys = metadata.patch(patch)
                 if new_keys:
                     LOG.warning(
-                        "[%s] The metadata patch created %d new key(s) that did not exist before: %s. "
-                        "This usually means the patch does not match this checkpoint's metadata schema, "
-                        "so the intended update was not applied.",
+                        "[%s] The metadata patch added %d new key(s) that did not exist before: %s. "
+                        "These keys were applied as given; if that was not intended, it usually means the "
+                        "patch does not match this checkpoint's metadata schema.",
                         dataset,
                         len(new_keys),
                         ", ".join(new_keys),

--- a/src/anemoi/inference/checkpoint.py
+++ b/src/anemoi/inference/checkpoint.py
@@ -26,6 +26,11 @@ from .metadata import SingleDatasetMetadata
 
 LOG = logging.getLogger(__name__)
 
+# Metadata keys whose creation by a `patch_metadata` patch is expected and must not trigger
+# the new-key warning emitted in `multi_dataset_metadata`. E.g. `constant_fields` is frequently
+# added through a patch even though it's not in the checkpoint metadata. TODO: find a better solution?
+EXPECTED_PATCH_NEW_KEYS = {"constant_fields"}
+
 
 def get_multi_dataset_metadata(
     metadata: dict,
@@ -182,6 +187,7 @@ class Checkpoint:
                 patch = multi_datasets_config(self.patch_metadata, dataset, list(multi_metadata.keys()), strict=False)
                 LOG.warning(f"[{dataset}] Patching metadata with {patch}")
                 new_keys = metadata.patch(patch)
+                new_keys = [key for key in new_keys if key.rsplit(".", 1)[-1] not in EXPECTED_PATCH_NEW_KEYS]
                 if new_keys:
                     LOG.warning(
                         "[%s] The metadata patch added %d new key(s) that did not exist before: %s. "

--- a/src/anemoi/inference/metadata.py
+++ b/src/anemoi/inference/metadata.py
@@ -1351,10 +1351,11 @@ class Metadata(LegacyMixin):
         -------
         list[str]
             Dotted paths of metadata keys that did not exist before and were created by
-            the patch. Only the top-most new key of any newly-created subtree is reported.
-            A non-empty list usually means the patch does not match this checkpoint's
-            metadata schema (e.g. a stale patch written for an older schema), so the
-            intended update was not applied.
+            the patch (the keys are still applied). Only the top-most new key of any
+            newly-created subtree is reported. A non-empty list may simply be a deliberate
+            addition, but it can also mean the patch does not match this checkpoint's
+            metadata schema (e.g. a stale patch written for an older schema) and an
+            intended update silently landed under a new key instead.
         """
 
         new_keys: list[str] = []

--- a/src/anemoi/inference/metadata.py
+++ b/src/anemoi/inference/metadata.py
@@ -1339,26 +1339,42 @@ class Metadata(LegacyMixin):
 
     ###########################################################################
 
-    def patch(self, patch: dict) -> None:
+    def patch(self, patch: dict) -> list[str]:
         """Patch the metadata with the given patch.
 
         Parameters
         ----------
         patch : dict
             The patch to apply.
+
+        Returns
+        -------
+        list[str]
+            Dotted paths of metadata keys that did not exist before and were created by
+            the patch. Only the top-most new key of any newly-created subtree is reported.
+            A non-empty list usually means the patch does not match this checkpoint's
+            metadata schema (e.g. a stale patch written for an older schema), so the
+            intended update was not applied.
         """
 
-        def merge(main: dict[str, Any], patch: dict[str, Any]) -> None:
+        new_keys: list[str] = []
+
+        def merge(main: dict[str, Any], patch: dict[str, Any], path: str = "", parent_is_new: bool = False) -> None:
 
             for k, v in patch.items():
+                key_path = f"{path}.{k}" if path else k
+                is_new = k not in main
+                if is_new and not parent_is_new:
+                    new_keys.append(key_path)
                 if isinstance(v, dict) and isinstance(main.get(k, {}), dict):
                     if k not in main:
                         main[k] = {}
-                    merge(main[k], v)
+                    merge(main[k], v, key_path, parent_is_new or is_new)
                 else:
                     main[k] = v
 
         merge(self._metadata, patch)
+        return new_keys
 
 
 class SingleDatasetMetadata(Metadata):

--- a/tests/unit/test_checkpoint.py
+++ b/tests/unit/test_checkpoint.py
@@ -15,7 +15,7 @@ from anemoi.inference.testing import fake_checkpoints
 
 @fake_checkpoints
 def test_patch_metadata_warns_on_new_keys(caplog) -> None:
-    """A patch that creates non-existing metadata keys must warn and name them."""
+    """A patch that creates non-existing metadata keys must warn, name them, yet still apply them."""
     from anemoi.inference.checkpoint import Checkpoint
 
     # `variable_metadata` is a typo for the real `variables_metadata` key: this is the
@@ -25,11 +25,15 @@ def test_patch_metadata_warns_on_new_keys(caplog) -> None:
         patch_metadata={"dataset": {"variable_metadata": {"2t": "patched"}}},
     )
     with caplog.at_level(logging.WARNING):
-        checkpoint.multi_dataset_metadata
+        metadata = checkpoint.multi_dataset_metadata
 
     assert any(
         "did not exist" in record.message and "dataset.variable_metadata" in record.message for record in caplog.records
     )
+
+    # the new key is warned about but still applied (adding missing keys can be deliberate)
+    patched = next(iter(metadata.values()))
+    assert patched._metadata["dataset"]["variable_metadata"] == {"2t": "patched"}
 
 
 @fake_checkpoints

--- a/tests/unit/test_checkpoint.py
+++ b/tests/unit/test_checkpoint.py
@@ -8,7 +8,43 @@
 # nor does it submit to any jurisdiction.
 
 
+import logging
+
 from anemoi.inference.testing import fake_checkpoints
+
+
+@fake_checkpoints
+def test_patch_metadata_warns_on_new_keys(caplog) -> None:
+    """A patch that creates non-existing metadata keys must warn and name them."""
+    from anemoi.inference.checkpoint import Checkpoint
+
+    # `variable_metadata` is a typo for the real `variables_metadata` key: this is the
+    # foot-gun from issue #452 where a stale patch silently adds keys instead of updating.
+    checkpoint = Checkpoint(
+        "unit/checkpoints/simple.ckpt",
+        patch_metadata={"dataset": {"variable_metadata": {"2t": "patched"}}},
+    )
+    with caplog.at_level(logging.WARNING):
+        checkpoint.multi_dataset_metadata
+
+    assert any(
+        "did not exist" in record.message and "dataset.variable_metadata" in record.message for record in caplog.records
+    )
+
+
+@fake_checkpoints
+def test_patch_metadata_no_warning_for_existing_keys(caplog) -> None:
+    """A patch that only updates existing metadata keys must not emit the new-key warning."""
+    from anemoi.inference.checkpoint import Checkpoint
+
+    checkpoint = Checkpoint(
+        "unit/checkpoints/simple.ckpt",
+        patch_metadata={"dataset": {"shape": [1, 2, 3, 4]}},
+    )
+    with caplog.at_level(logging.WARNING):
+        checkpoint.multi_dataset_metadata
+
+    assert not any("did not exist" in record.message for record in caplog.records)
 
 
 @fake_checkpoints

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -43,6 +43,41 @@ def test_patch(initial, patch, expected):
     assert metadata._metadata["config"]["dataloader"] == expected
 
 
+@pytest.mark.parametrize(
+    "initial, patch, expected_new_keys",
+    [
+        # updating an existing leaf does not create any new key
+        (
+            {"config": {"dataloader": {"dataset": "abc"}}},
+            {"config": {"dataloader": {"dataset": "xyz"}}},
+            [],
+        ),
+        # a new nested subtree is reported by its top-most new key only
+        (
+            {"config": {"dataloader": {"dataset": "abc"}}},
+            {"config": {"dataloader": {"something": {"else": "123"}}}},
+            ["config.dataloader.something"],
+        ),
+        # a new leaf alongside an existing one is reported on its own
+        (
+            {"a": {"b": 1, "c": 2}},
+            {"a": {"c": 3, "d": 4}},
+            ["a.d"],
+        ),
+        # a brand-new top-level key is reported
+        (
+            {"a": 1},
+            {"b": 2},
+            ["b"],
+        ),
+    ],
+)
+def test_patch_returns_new_keys(initial, patch, expected_new_keys):
+    metadata = MetadataFactory(initial)
+    new_keys = metadata.patch(patch)
+    assert new_keys == expected_new_keys
+
+
 def test_constant_fields_patch():
     model_metadata = mock_load_metadata("unit/checkpoints/atmos.json", supporting_arrays=False)
     metadata = MetadataFactory(model_metadata)


### PR DESCRIPTION
## Description

The `patch_metadata` config entry patches checkpoint metadata on the fly. Patches are written against the metadata schema of the anemoi versions that produced the checkpoint. When the same patch is applied to a checkpoint with a **newer** metadata schema, the inner `merge()` in `Metadata.patch()` silently **adds** new keys instead of updating the intended existing ones — the update is lost and the failure is hard to debug.

## Changes

- `Metadata.patch()` now returns the dotted paths of metadata keys it **created** (only the top-most new key of any newly-created subtree is reported). The merge behavior is otherwise unchanged.
- The user-facing `patch_metadata` path in `Checkpoint` emits a `LOG.warning` naming those keys, so a schema mismatch is surfaced instead of failing silently.
- Internal patches in `external_graph.py` (which intentionally add keys) simply ignore the return value, so they produce no spurious warnings.
- Adds unit tests for the returned key paths and for the warning.

Closes #452