### PR TITLE
fix(parallel runner): Reorder configuration steps

### DIFF
--- a/src/anemoi/inference/runners/parallel.py
+++ b/src/anemoi/inference/runners/parallel.py
@@ -127,8 +127,6 @@ class ParallelRunnerMixin(Runner):
             The compute client to use for distributed inference
         """
 
-        super().__init__(config, **kwargs)
-
         compute_client = compute_client or create_cluster(config.cluster or {}).create_client()  # type: ignore
         assert isinstance(compute_client, ComputeClient), "Compute client must be an instance of ComputeClient."
 
@@ -137,6 +135,12 @@ class ParallelRunnerMixin(Runner):
         LOG.info(f"{compute_client!r}")
 
         self.compute_client = compute_client
+        self.is_master = compute_client.is_master
+
+        super().__init__(config, **kwargs)
+
+        # give the base class an opportunity to modify the parallel runner
+        super()._configure_parallel_runner()
 
         if self.device.type == "cuda":
             self.device = torch.device("cuda", index=compute_client.local_rank)
@@ -145,12 +149,7 @@ class ParallelRunnerMixin(Runner):
         else:
             LOG.warning(f"ParallelRunner device `{self.device}` is unchanged")
 
-        self.compute_client = compute_client
-        self.is_master = compute_client.is_master
         self.seed(compute_client.process_group)
-
-        # give the base class an opportunity to modify the parallel runner
-        super()._configure_parallel_runner()
 
         # disable most logging on non-zero ranks
         if not self.is_master and self.verbosity == 0:

--- a/src/anemoi/inference/runners/parallel.py
+++ b/src/anemoi/inference/runners/parallel.py
@@ -138,9 +138,6 @@ class ParallelRunnerMixin(Runner):
 
         self.compute_client = compute_client
 
-        # give the base class an opportunity to modify the parallel runner
-        super()._configure_parallel_runner()
-
         if self.device.type == "cuda":
             self.device = torch.device("cuda", index=compute_client.local_rank)
             torch.cuda.set_device(self.device)
@@ -151,6 +148,9 @@ class ParallelRunnerMixin(Runner):
         self.compute_client = compute_client
         self.is_master = compute_client.is_master
         self.seed(compute_client.process_group)
+
+        # give the base class an opportunity to modify the parallel runner
+        super()._configure_parallel_runner()
 
         # disable most logging on non-zero ranks
         if not self.is_master and self.verbosity == 0:


### PR DESCRIPTION
## Description
`Parallel` output was broken by changes to init order from multi datasets, as an output is created in the `super().__init__`

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
