### PR TITLE
chore(deps): Pin matplotlib<3.11.0 in plot group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ optional-dependencies.huggingface = [ "huggingface-hub" ]
 optional-dependencies.netcdf = [ "earthkit-data>=0.19,<1" ]
 optional-dependencies.plot = [
   "earthkit-plots<1",
-  "matplotlib<3.11",
+  "matplotlib<3.11",  # TODO: remove when we start using ekp 1.0
 ]
 optional-dependencies.tests = [
   "anemoi-datasets[all]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,10 @@ optional-dependencies.docs = [
 ]
 optional-dependencies.huggingface = [ "huggingface-hub" ]
 optional-dependencies.netcdf = [ "earthkit-data>=0.19,<1" ]
-optional-dependencies.plot = [ "earthkit-plots<1" ]
+optional-dependencies.plot = [
+  "earthkit-plots<1",
+  "matplotlib<3.11",
+]
 optional-dependencies.tests = [
   "anemoi-datasets[all]",
   "anemoi-inference[all]",


### PR DESCRIPTION
## Description
matplotlib==3.11.0 breaks earthkit-plots, but we currently pin ekp<1.0 and it's unlikely to be fixed in ekp<1.0. So pin matplotlib for now, and remove it again when we go to ekp 1.0.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
