### PR TITLE
fix(inputs/ekd): update geography information handling unstructured grids

### DIFF
--- a/src/anemoi/inference/inputs/ekd.py
+++ b/src/anemoi/inference/inputs/ekd.py
@@ -483,7 +483,9 @@ class EkdInput(Input):
         grid = get_geography_info("mars_grid")
         if grid == "undefined":
             grid = {"latitudes": list(state["latitudes"]), "longitudes": list(state["longitudes"])}
-        else:
+            geography_information["grid"] = grid
+
+        else:  # If grid is undefined we don't want to add the area
             if grid:
                 geography_information["grid"] = grid
 

--- a/src/anemoi/inference/inputs/ekd.py
+++ b/src/anemoi/inference/inputs/ekd.py
@@ -480,10 +480,14 @@ class EkdInput(Input):
                 return combo[0]
             return None
 
-        if area := get_geography_info("mars_area"):
-            geography_information["area"] = area
-        if grid := get_geography_info("mars_grid"):
+        grid = get_geography_info("mars_grid")
+        if grid is not None and grid == "undefined":
+            grid = {"latitudes": list(state["latitudes"]), "longitudes": list(state["longitudes"])}
+        else:
             geography_information["grid"] = grid
+
+            if area := get_geography_info("mars_area"):
+                geography_information["area"] = area
 
         if geography_information:
             state["_geography"] = geography_information

--- a/src/anemoi/inference/inputs/ekd.py
+++ b/src/anemoi/inference/inputs/ekd.py
@@ -481,10 +481,11 @@ class EkdInput(Input):
             return None
 
         grid = get_geography_info("mars_grid")
-        if grid is not None and grid == "undefined":
+        if grid == "undefined":
             grid = {"latitudes": list(state["latitudes"]), "longitudes": list(state["longitudes"])}
         else:
-            geography_information["grid"] = grid
+            if grid:
+                geography_information["grid"] = grid
 
             if area := get_geography_info("mars_area"):
                 geography_information["area"] = area


### PR DESCRIPTION
## Description
When input fields were unstructured, the `mars_grid` would return `undefined`, and cause issues with downstream template providers. If this case is encountered, this PR changes it such that the lat / lon's are recorded, in compliance with ECMWF grid_spec formats.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
