### PR TITLE
fix: change VariableFromMarsVocabulary to Variable.from_dict

### DIFF
--- a/src/anemoi/inference/runner.py
+++ b/src/anemoi/inference/runner.py
@@ -23,7 +23,7 @@ from typing import Literal
 from typing import Union
 
 import numpy as np
-from anemoi.transform.variables.variables import VariableFromMarsVocabulary
+from anemoi.transform.variables import Variable
 from anemoi.utils.config import DotDict
 from anemoi.utils.dates import frequency_to_timedelta as to_timedelta
 from anemoi.utils.timer import Timer
@@ -105,7 +105,7 @@ class Runner(Context):
         self.use_profiler = config.use_profiler
 
         # other attributes derived from config or metadata
-        self.typed_variables = {k: VariableFromMarsVocabulary(k, v) for k, v in config.typed_variables.items()}
+        self.typed_variables = {k: Variable.from_dict(k, v) for k, v in config.typed_variables.items()}
         self.preload_checkpoint = config.preload_checkpoint
         self.preload_buffer_size = config.preload_buffer_size
         self.precision = config.precision

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -17,7 +17,7 @@ from typing import NamedTuple
 
 import numpy as np
 import pytest
-from anemoi.transform.variables.variables import VariableFromMarsVocabulary
+from anemoi.transform.variables import Variable
 from anemoi.utils.testing import TEST_DATA_URL
 from anemoi.utils.testing import GetTestData
 from omegaconf import DictConfig
@@ -227,7 +227,7 @@ def test_integration(test_setup: Setup, tmp_path: Path) -> None:
         # config can optionally pass expected output variables, by default it uses the checkpoint variables
         expected_variables_config = kwargs.pop("expected_variables", [])
         expected_variables = [
-            VariableFromMarsVocabulary(var, {"param": var}) for var in expected_variables_config
+            Variable.from_dict(var, {"param": var}) for var in expected_variables_config
         ] or checkpoint_output_variables[dataset_name]
 
         testing_registry.create(


### PR DESCRIPTION
## Description
Extracted from #513 (and applied to integration tests).

This PR would allow https://github.com/ecmwf/anemoi-transform/pull/306 to be merged without requiring anemoi-inference to update its anemoi-transform dependency. (And so #513 can be reviewed independently).

According to @b8raoult `VariableFromMarsVocabulary` should be considered a private interface, so using the class method `Variable.from_dict` is preferred.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
