### PR TITLE
feat(dataset input): add warning for preprocessors

### DIFF
--- a/src/anemoi/inference/inputs/dataset.py
+++ b/src/anemoi/inference/inputs/dataset.py
@@ -10,6 +10,7 @@
 
 import json
 import logging
+import warnings
 from functools import cached_property
 from typing import Any
 
@@ -95,6 +96,7 @@ class DatasetInput(Input):
                 context._warn_once(msg)
             else:
                 LOG.warning(msg)
+                warnings.warn(msg, UserWarning, stacklevel=2)
 
     @cached_property
     def ds(self) -> Any:

--- a/src/anemoi/inference/inputs/dataset.py
+++ b/src/anemoi/inference/inputs/dataset.py
@@ -82,6 +82,18 @@ class DatasetInput(Input):
 
         self.grid_indices = slice(None) if grid_indices is None else grid_indices
 
+        has_pre_processors = bool(self._pre_processor_confs) or (
+            hasattr(context, "pre_processors") and bool(context.pre_processors.get(self.dataset_name, []))
+        )
+        if has_pre_processors:
+            LOG.warning(
+                "Pre-processors are configured for dataset '%s' but will NOT be applied "
+                "by '%s'. This input type reads data directly from a pre-built dataset "
+                "and does not invoke the pre-processor pipeline.",
+                self.dataset_name,
+                self.__class__.__name__,
+            )
+
     @cached_property
     def ds(self) -> Any:
         """Return the dataset."""

--- a/src/anemoi/inference/inputs/dataset.py
+++ b/src/anemoi/inference/inputs/dataset.py
@@ -86,13 +86,15 @@ class DatasetInput(Input):
             hasattr(context, "pre_processors") and bool(context.pre_processors.get(self.dataset_name, []))
         )
         if has_pre_processors:
-            LOG.warning(
-                "Pre-processors are configured for dataset '%s' but will NOT be applied "
-                "by '%s'. This input type reads data directly from a pre-built dataset "
-                "and does not invoke the pre-processor pipeline.",
-                self.dataset_name,
-                self.__class__.__name__,
+            msg = (
+                f"Pre-processors are configured for dataset '{self.dataset_name}' but will NOT be applied "
+                f"by '{self.__class__.__name__}'. This input type reads data directly from a pre-built dataset "
+                "and does not invoke the pre-processor pipeline."
             )
+            if hasattr(context, "_warn_once"):
+                context._warn_once(msg)
+            else:
+                LOG.warning(msg)
 
     @cached_property
     def ds(self) -> Any:

--- a/src/anemoi/inference/runner.py
+++ b/src/anemoi/inference/runner.py
@@ -918,4 +918,5 @@ class Runner(Context):
         """Log a warning message only once."""
         if message not in self.quiet:
             LOG.warning(message)
+            warnings.warn(message, UserWarning, stacklevel=2)
             self.quiet.add(message)

--- a/src/anemoi/inference/runner.py
+++ b/src/anemoi/inference/runner.py
@@ -111,6 +111,8 @@ class Runner(Context):
         self.precision = config.precision
         self.reference_date = config.date if hasattr(config, "date") else None
 
+        self.quiet: set[str] = set()  # So we don't repeat the same warning multiple times
+
         # processors, I/O and tensor handlers for each dataset in the checkpoint
         self.pre_processors: dict[str, list[Processor]] = {}
         self.post_processors: dict[str, list[Processor]] = {}
@@ -165,8 +167,6 @@ class Runner(Context):
                     table.add_row(variable, str(units), ", ".join(categories))
 
                 console.print(table)
-
-        self.quiet = set()  # So we don't repeat the same warning multiple times
 
     @property
     def checkpoint(self) -> Checkpoint:

--- a/tests/unit/inputs/test_dataset_preprocessor_warning.py
+++ b/tests/unit/inputs/test_dataset_preprocessor_warning.py
@@ -9,7 +9,9 @@
 
 import warnings
 from types import SimpleNamespace
+
 import pytest
+
 from anemoi.inference.inputs.dataset import DatasetInput
 
 _CTX = SimpleNamespace(verbosity=0, reference_date=None)

--- a/tests/unit/inputs/test_dataset_preprocessor_warning.py
+++ b/tests/unit/inputs/test_dataset_preprocessor_warning.py
@@ -10,7 +10,6 @@
 import warnings
 from types import SimpleNamespace
 
-
 from anemoi.inference.inputs.dataset import DatasetInput
 
 _CTX = SimpleNamespace(verbosity=0, reference_date=None)

--- a/tests/unit/inputs/test_dataset_preprocessor_warning.py
+++ b/tests/unit/inputs/test_dataset_preprocessor_warning.py
@@ -9,7 +9,7 @@
 
 import warnings
 from types import SimpleNamespace
-
+import pytest
 from anemoi.inference.inputs.dataset import DatasetInput
 
 _CTX = SimpleNamespace(verbosity=0, reference_date=None)

--- a/tests/unit/inputs/test_dataset_preprocessor_warning.py
+++ b/tests/unit/inputs/test_dataset_preprocessor_warning.py
@@ -1,0 +1,39 @@
+# (C) Copyright 2024 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from anemoi.inference.inputs.dataset import DatasetInput
+
+_CTX = SimpleNamespace(verbosity=0, reference_date=None)
+_META = SimpleNamespace(dataset_name="test_dataset", _supporting_arrays={})
+_KWARGS = dict(variables=[], open_dataset_args=(), open_dataset_kwargs={})
+
+
+def test_warning_logged_when_pre_processors_configured(caplog):
+    with caplog.at_level(logging.WARNING, logger="anemoi.inference.inputs.dataset"):
+        DatasetInput(_CTX, _META, pre_processors=[{"scale": {}}], **_KWARGS)
+    assert any("will NOT be applied" in r.message for r in caplog.records)
+
+
+def test_no_warning_when_no_pre_processors(caplog):
+    with caplog.at_level(logging.WARNING, logger="anemoi.inference.inputs.dataset"):
+        DatasetInput(_CTX, _META, **_KWARGS)
+    assert not any("will NOT be applied" in r.message for r in caplog.records)
+
+
+def test_uses_warn_once_when_available():
+    warned = []
+    ctx = SimpleNamespace(verbosity=0, reference_date=None, _warn_once=warned.append)
+    DatasetInput(ctx, _META, pre_processors=[{"scale": {}}], **_KWARGS)
+    assert len(warned) == 1
+    assert "will NOT be applied" in warned[0]

--- a/tests/unit/inputs/test_dataset_preprocessor_warning.py
+++ b/tests/unit/inputs/test_dataset_preprocessor_warning.py
@@ -10,7 +10,6 @@
 import logging
 from types import SimpleNamespace
 
-import pytest
 
 from anemoi.inference.inputs.dataset import DatasetInput
 

--- a/tests/unit/inputs/test_dataset_preprocessor_warning.py
+++ b/tests/unit/inputs/test_dataset_preprocessor_warning.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2024 Anemoi contributors.
+# (C) Copyright 2026- Anemoi contributors.
 #
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
@@ -7,7 +7,7 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-import logging
+import warnings
 from types import SimpleNamespace
 
 
@@ -18,21 +18,24 @@ _META = SimpleNamespace(dataset_name="test_dataset", _supporting_arrays={})
 _KWARGS = dict(variables=[], open_dataset_args=(), open_dataset_kwargs={})
 
 
-def test_warning_logged_when_pre_processors_configured(caplog):
-    with caplog.at_level(logging.WARNING, logger="anemoi.inference.inputs.dataset"):
+def test_warning_logged_when_pre_processors_configured():
+    with pytest.warns(UserWarning, match="will NOT be applied"):
         DatasetInput(_CTX, _META, pre_processors=[{"scale": {}}], **_KWARGS)
-    assert any("will NOT be applied" in r.message for r in caplog.records)
 
 
-def test_no_warning_when_no_pre_processors(caplog):
-    with caplog.at_level(logging.WARNING, logger="anemoi.inference.inputs.dataset"):
-        DatasetInput(_CTX, _META, **_KWARGS)
-    assert not any("will NOT be applied" in r.message for r in caplog.records)
+def test_no_warning_when_no_pre_processors(recwarn):
+    DatasetInput(_CTX, _META, **_KWARGS)
+    assert not any("will NOT be applied" in str(w.message) for w in recwarn.list)
 
 
 def test_uses_warn_once_when_available():
-    warned = []
-    ctx = SimpleNamespace(verbosity=0, reference_date=None, _warn_once=warned.append)
-    DatasetInput(ctx, _META, pre_processors=[{"scale": {}}], **_KWARGS)
-    assert len(warned) == 1
-    assert "will NOT be applied" in warned[0]
+    call_count = [0]
+
+    def mock_warn_once(msg):
+        call_count[0] += 1
+        warnings.warn(msg, UserWarning)
+
+    ctx = SimpleNamespace(verbosity=0, reference_date=None, _warn_once=mock_warn_once)
+    with pytest.warns(UserWarning, match="will NOT be applied"):
+        DatasetInput(ctx, _META, pre_processors=[{"scale": {}}], **_KWARGS)
+    assert call_count[0] == 1


### PR DESCRIPTION
## Description
Add a warning log message when pre-processors are configured alongside a DatasetInput, which reads data directly from a pre-built dataset file and does not invoke the pre-processor pipeline. 

## What problem does this change solve?
When users configure pre_processors together with a dataset-based input, the pre-processors have no effect but no feedback is given. This adds an explicit WARNING log entry at runner initialisation time, naming the dataset and the input class responsible, so the misconfiguration is visible in the log.

## What issue or task does this change relate to?
[<!-- link to Issue Number -->](https://github.com/ecmwf/anemoi-inference/issues/518)

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
