### PR TITLE
feat(dataset input): add use_trajectories option

### DIFF
--- a/docs/inference/configs/inputs.rst
+++ b/docs/inference/configs/inputs.rst
@@ -50,6 +50,9 @@ This allows for forecasts to be included in the dataset, and for the model to in
 
 Setting `use_trajectories` in a dataset input will allow for the model to be initialised from the forecast, filtering by valid_time, rather than just the basetime.
 
+In the case of the initial conditions, the prior dates, the model will be initialised from step 0 of the dataset, i.e. the analysis, with future forcings coming from the forecast steps, with the base date
+being the date specified in the config, the base_date.
+
 
 .. code:: yaml
 

--- a/docs/inference/configs/inputs.rst
+++ b/docs/inference/configs/inputs.rst
@@ -46,9 +46,9 @@ Trajectory Inputs
 #################
 
 `anemoi-datasets` `v0.5.38` introduced a new feature to allow for trajectory datasets, introducing a 5th dimension to the dataset.
-This allows for forecasts to be included in the dataset, and for the model to initialised from steps of a model, not just the analysis.
+This allows for forecasts to be included in the dataset, and for inference it means that it is possible for the model to be forced from steps of a model, not just the analysis.
 
-Setting `use_trajectories` in a dataset input will allow for the model to be initialised from the forecast, filtering by valid_time, rather than just the basetime.
+Setting `use_trajectories` in a dataset input will allow for the model to be forced from the forecasts within the dataset, filtering by step and the basetime of the run, rather than just the absolute time throughout the run.
 
 In the case of the initial conditions, the prior dates, the model will be initialised from step 0 of the dataset, i.e. the analysis, with future forcings coming from the forecast steps, with the base date
 being the date specified in the config, the base_date.

--- a/docs/inference/configs/inputs.rst
+++ b/docs/inference/configs/inputs.rst
@@ -41,6 +41,22 @@ You can also provide a full dataset specification as follows:
 See :ref:`anemoi-datasets:opening-datasets` in the documentation of the
 `anemoi-datasets` package for more information on how to open datasets.
 
+#################
+Trajectory Inputs
+#################
+
+`anemoi-datasets` `v0.5.38` introduced a new feature to allow for trajectory datasets, introducing a 5th dimension to the dataset.
+This allows for forecasts to be included in the dataset, and for the model to initialised from steps of a model, not just the analysis.
+
+Setting `use_trajectories` in a dataset input will allow for the model to be initialised from the forecast, filtering by valid_time, rather than just the basetime.
+
+
+.. code:: yaml
+
+   input:
+      test:
+       use_trajectories: true
+
 ******
  grib
 ******

--- a/docs/inference/configs/inputs.rst
+++ b/docs/inference/configs/inputs.rst
@@ -54,8 +54,9 @@ Setting `use_trajectories` in a dataset input will allow for the model to be ini
 .. code:: yaml
 
    input:
-      test:
-       use_trajectories: true
+      dataset:
+         PATH_GOES_HERE
+         use_trajectories: true
 
 ******
  grib

--- a/src/anemoi/inference/inputs/dataset.py
+++ b/src/anemoi/inference/inputs/dataset.py
@@ -113,6 +113,13 @@ class DatasetInput(Input):
         return dataset
 
     @cached_property
+    def ds_dates(self) -> np.ndarray:
+        """Return the dates of the dataset."""
+        if hasattr(self.ds, "base_dates"):
+            return self.ds.base_dates
+        return self.ds.dates
+
+    @cached_property
     def latitudes(self) -> FloatArray:
         """Return the latitudes."""
         return self.ds.latitudes
@@ -238,10 +245,10 @@ class DatasetInput(Input):
         int
             The index of the date in the dataset.
         """
-        (i,) = np.where(self.ds.base_dates == np.datetime64(date))
+        (i,) = np.where(self.ds_dates == np.datetime64(date))
         if len(i) == 0:
             raise ValueError(
-                f"Date {date} not found in the dataset, available base_dates: {self.ds.base_dates[0]}...{self.ds.base_dates[-1]}"
+                f"Date {date} not found in the dataset, available base_dates: {self.ds_dates[0]}...{self.ds_dates[-1]}"
             )
         assert len(i) == 1, f"Multiple dates found for {date}"
         return int(i[0])

--- a/src/anemoi/inference/inputs/dataset.py
+++ b/src/anemoi/inference/inputs/dataset.py
@@ -86,16 +86,6 @@ class DatasetInput(Input):
                     the input grid will be reduced accordingly.")
 
         self.grid_indices = slice(None) if grid_indices is None else grid_indices
-        self.use_trajectories = use_trajectories
-
-        if not len(self.ds.shape) == 5 and self.use_trajectories:
-            raise ValueError(
-                f"Expected dataset with 5 dimensions (base_dates, variables, ensembles, steps, cells) as a trajectory dataset, got {len(self.ds.shape)} dimensions. Is this a trajectory dataset?"
-            )
-        elif len(self.ds.shape) == 5 and not self.use_trajectories:
-            raise ValueError(
-                f"Expected dataset with 4 dimensions (base_dates, variables, ensembles, cells) as a non-trajectory dataset, got {len(self.ds.shape)} dimensions. Is this a trajectory dataset?"
-            )
 
         has_pre_processors = bool(self._pre_processor_confs) or (
             hasattr(context, "pre_processors") and bool(context.pre_processors.get(self.dataset_name, []))
@@ -112,6 +102,17 @@ class DatasetInput(Input):
             else:
                 LOG.warning(msg)
                 warnings.warn(msg, UserWarning, stacklevel=2)
+
+        self.use_trajectories = use_trajectories
+
+        if not len(self.ds.shape) == 5 and self.use_trajectories:
+            raise ValueError(
+                f"Expected dataset with 5 dimensions (base_dates, variables, ensembles, steps, cells) as a trajectory dataset, got {len(self.ds.shape)} dimensions. Is this a trajectory dataset?"
+            )
+        elif len(self.ds.shape) == 5 and not self.use_trajectories:
+            raise ValueError(
+                f"Expected dataset with 4 dimensions (base_dates, variables, ensembles, cells) as a non-trajectory dataset, got {len(self.ds.shape)} dimensions. Is this a trajectory dataset?"
+            )
 
     @cached_property
     def ds(self) -> Any:

--- a/src/anemoi/inference/inputs/dataset.py
+++ b/src/anemoi/inference/inputs/dataset.py
@@ -211,7 +211,8 @@ class DatasetInput(Input):
         State
             The loaded forcings state.
         """
-        data = self._load_dates(dates, base_date=current_state["date"])  # (date, variables, ensemble, values)
+        base_date = current_state["date"] - current_state["step"]
+        data = self._load_dates(dates, base_date=base_date)  # (date, variables, ensemble, values)
 
         requested_variables = np.array([self.ds.name_to_index[v] for v in self.variables])
         data = data[:, requested_variables]
@@ -298,21 +299,33 @@ class DatasetInput(Input):
             The loaded data.
         """
         base_idx = self._find_index_for_date(base_date)
-        step_index = [int(np.timedelta64(d - base_date) / self.ds.step_frequency) for d in dates]
-        LOG.info("Loading trajectory data for base_date=%s, steps=%s", base_date, step_index)
-        # Convert to slice if consecutive (dataset indexing with lists can be unreliable)
-        if len(step_index) == 1:
-            step_slice = slice(step_index[0], step_index[0] + 1)
-        else:
-            diff = step_index[1] - step_index[0]
-            if all(step_index[i + 1] - step_index[i] == diff for i in range(len(step_index) - 1)):
-                step_slice = slice(step_index[0], step_index[-1] + 1, diff)
+
+        datalist = []
+        dates_before_base = [d for d in dates if d <= base_date]
+        dates_after_base = [d for d in dates if d > base_date]
+
+        for d in dates_before_base:
+            LOG.info("Loading data at step 0 for date=%s", d)
+            datalist.append(self._load_basedates([d])[:, :, :, 0])
+
+        if len(dates_after_base) > 0:
+            step_index = [int(np.timedelta64(d - base_date) / self.ds.step_frequency) for d in dates_after_base]
+            LOG.info("Loading data from trajectory at base_date=%s, steps=%s", base_date, step_index)
+            # Convert to slice if consecutive (dataset indexing with lists can be unreliable)
+            if len(step_index) == 1:
+                step_slice = slice(step_index[0], step_index[0] + 1)
             else:
-                raise ValueError("Requested dates do not have a uniform step spacing")
-        data = self.ds[base_idx, :, :, step_slice]
-        # Transpose to (steps/dates, variables, ensemble, cells) to match _load_basedates
-        data = np.moveaxis(data, 2, 0)
-        return data
+                diff = step_index[1] - step_index[0]
+                if all(step_index[i + 1] - step_index[i] == diff for i in range(len(step_index) - 1)):
+                    step_slice = slice(step_index[0], step_index[-1] + 1, diff)
+                else:
+                    raise ValueError("Requested dates do not have a uniform step spacing")
+            trajectory_data = self.ds[base_idx, :, :, step_slice]
+            # Transpose to (steps/dates, variables, ensemble, cells) to match _load_basedates
+            trajectory_data = np.moveaxis(trajectory_data, 2, 0)
+            datalist.append(trajectory_data)
+
+        return np.concatenate(datalist, axis=0)
 
     def _load_dates(self, dates: list[Date], base_date: Date) -> Any:
         """Load the data for the given dates.

--- a/src/anemoi/inference/inputs/dataset.py
+++ b/src/anemoi/inference/inputs/dataset.py
@@ -92,6 +92,10 @@ class DatasetInput(Input):
             raise ValueError(
                 f"Expected dataset with 5 dimensions (base_dates, variables, ensembles, steps, cells) as a trajectory dataset, got {len(self.ds.shape)} dimensions. Is this a trajectory dataset?"
             )
+        elif len(self.ds.shape) == 5 and not self.use_trajectories:
+            raise ValueError(
+                f"Expected dataset with 4 dimensions (base_dates, variables, ensembles, cells) as a non-trajectory dataset, got {len(self.ds.shape)} dimensions. Is this a trajectory dataset?"
+            )
 
     @cached_property
     def ds(self) -> Any:

--- a/src/anemoi/inference/inputs/dataset.py
+++ b/src/anemoi/inference/inputs/dataset.py
@@ -40,6 +40,7 @@ class DatasetInput(Input):
         open_dataset_args: tuple[Any, ...],
         open_dataset_kwargs: dict[str, Any],
         grid_indices: Any = None,
+        use_trajectories: bool = False,
         **kwargs: Any,
     ) -> None:
         """Initialize the DatasetInput.
@@ -56,6 +57,9 @@ class DatasetInput(Input):
             Keyword arguments for the dataset.
         grid_indices : Optional[Any]
             Indices to reduce the input grid. If None, the full grid is used.
+        use_trajectories : bool
+            Whether to expect dataset as a trajectory (i.e. with a `step / forecast` dimension),
+            and to get multiple dates from within a single trajectory.
         **kwargs : Any
             Additional keyword arguments.
         """
@@ -81,6 +85,13 @@ class DatasetInput(Input):
                     the input grid will be reduced accordingly.")
 
         self.grid_indices = slice(None) if grid_indices is None else grid_indices
+
+        self.use_trajectories = use_trajectories
+
+        if not len(self.ds.shape) == 5 and self.use_trajectories:
+            raise ValueError(
+                f"Expected dataset with 5 dimensions (base_dates, variables, ensembles, steps, cells) as a trajectory dataset, got {len(self.ds.shape)} dimensions. Is this a trajectory dataset?"
+            )
 
     @cached_property
     def ds(self) -> Any:
@@ -150,7 +161,7 @@ class DatasetInput(Input):
         else:
             dates = [date + np.timedelta64(h) for h in self.metadata.lagged]
 
-        data = self._load_dates(dates)
+        data = self._load_dates(dates, base_date=date)
 
         if data.shape[2] != 1:
             raise ValueError(f"Ensemble data not supported, got {data.shape[2]} members")
@@ -189,7 +200,7 @@ class DatasetInput(Input):
         State
             The loaded forcings state.
         """
-        data = self._load_dates(dates)  # (date, variables, ensemble, values)
+        data = self._load_dates(dates, base_date=current_state["date"])  # (date, variables, ensemble, values)
 
         requested_variables = np.array([self.ds.name_to_index[v] for v in self.variables])
         data = data[:, requested_variables]
@@ -210,13 +221,34 @@ class DatasetInput(Input):
             longitudes=self.longitudes,
         )
 
-    def _load_dates(self, dates: list[Date]) -> Any:
-        """Load the data for the given dates.
+    def _find_index_for_date(self, date: Date) -> int:
+        """Find the index of the given date in the dataset.
 
         Parameters
         ----------
-        dates : List[Any]
-            List of dates for which to load the data.
+        date : Any
+            The date for which to find the index.
+
+        Returns
+        -------
+        int
+            The index of the date in the dataset.
+        """
+        (i,) = np.where(self.ds.base_dates == np.datetime64(date))
+        if len(i) == 0:
+            raise ValueError(
+                f"Date {date} not found in the dataset, available base_dates: {self.ds.base_dates[0]}...{self.ds.base_dates[-1]}"
+            )
+        assert len(i) == 1, f"Multiple dates found for {date}"
+        return int(i[0])
+
+    def _load_basedates(self, basedates: list[Date]) -> Any:
+        """Load the data for the given base dates.
+
+        Parameters
+        ----------
+        basedates : List[Any]
+            List of base dates for which to load the data.
 
         Returns
         -------
@@ -224,18 +256,9 @@ class DatasetInput(Input):
             The loaded data.
         """
         # TODO: use the fact that the dates are sorted
-
-        dataset_dates = self.ds.dates
-
         idx = []
-        for d in dates:
-            (i,) = np.where(dataset_dates == d)
-            if len(i) == 0:
-                raise ValueError(
-                    f"Date {d} not found in the dataset, available dates: {dataset_dates[0]}...{dataset_dates[-1]} by {self.ds.frequency}"
-                )
-            assert len(i) == 1, f"Multiple dates found for {d}"
-            idx.append(int(i[0]))
+        for d in basedates:
+            idx.append(self._find_index_for_date(d))
 
         if len(idx) == 1:
             s = slice(idx[0], idx[0] + 1)
@@ -247,6 +270,57 @@ class DatasetInput(Input):
             s = slice(idx[0], idx[-1] + 1, diff)
 
         return self.ds[s]
+
+    def _load_trajectories(self, dates: list[Date], base_date: Date) -> Any:
+        """Load the data for the given dates as trajectories.
+
+        Parameters
+        ----------
+        dates : List[Any]
+            List of dates for which to load the data.
+        base_date : Any
+            The base date for relative date calculations.
+
+        Returns
+        -------
+        Any
+            The loaded data.
+        """
+        base_idx = self._find_index_for_date(base_date)
+        step_index = [int(np.timedelta64(d - base_date) / self.ds.step_frequency) for d in dates]
+        LOG.info("Loading trajectory data for base_date=%s, steps=%s", base_date, step_index)
+        # Convert to slice if consecutive (dataset indexing with lists can be unreliable)
+        if len(step_index) == 1:
+            step_slice = slice(step_index[0], step_index[0] + 1)
+        else:
+            diff = step_index[1] - step_index[0]
+            if all(step_index[i + 1] - step_index[i] == diff for i in range(len(step_index) - 1)):
+                step_slice = slice(step_index[0], step_index[-1] + 1, diff)
+            else:
+                raise ValueError("Requested dates do not have a uniform step spacing")
+        data = self.ds[base_idx, :, :, step_slice]
+        # Transpose to (steps/dates, variables, ensemble, cells) to match _load_basedates
+        data = np.moveaxis(data, 2, 0)
+        return data
+
+    def _load_dates(self, dates: list[Date], base_date: Date) -> Any:
+        """Load the data for the given dates.
+
+        Parameters
+        ----------
+        dates : List[Any]
+            List of dates for which to load the data.
+        base_date : Any
+            The base date for relative date calculations.
+
+        Returns
+        -------
+        Any
+            The loaded data.
+        """
+        if not self.use_trajectories:
+            return self._load_basedates(dates)
+        return self._load_trajectories(dates, base_date=base_date)
 
 
 @input_registry.register("dataset")
@@ -265,6 +339,7 @@ class DatasetInputArgsKwargs(DatasetInput):
         pre_processors: list[ProcessorConfig] | None = None,
         grid_indices=None,
         purpose: str | None = None,
+        use_trajectories: bool = False,
         **kwargs: Any,
     ) -> None:
         """Initialize the DatasetInputArgsKwargs.
@@ -277,10 +352,15 @@ class DatasetInputArgsKwargs(DatasetInput):
             Metadata corresponding to the dataset this input is handling.
         use_original_paths : bool
             Whether to use original paths.
+        use_trajectories : bool
+            Whether to expect dataset as a trajectory (i.e. with a `step / forecast` dimension),
+            and to get multiple dates from within a single trajectory.
         """
 
         check_variables_compatibility = multi_datasets_config(
-            context.config.check_variables_compatibility, metadata.dataset_name, context.dataset_names
+            context.config.check_variables_compatibility,
+            metadata.dataset_name,
+            context.dataset_names,
         )
 
         if not args and not kwargs:
@@ -311,6 +391,7 @@ class DatasetInputArgsKwargs(DatasetInput):
             open_dataset_args=args,
             open_dataset_kwargs=kwargs,
             purpose=purpose,
+            use_trajectories=use_trajectories,
         )
 
 

--- a/src/anemoi/inference/inputs/dataset.py
+++ b/src/anemoi/inference/inputs/dataset.py
@@ -86,6 +86,7 @@ class DatasetInput(Input):
                     the input grid will be reduced accordingly.")
 
         self.grid_indices = slice(None) if grid_indices is None else grid_indices
+        self.use_trajectories = use_trajectories
 
         has_pre_processors = bool(self._pre_processor_confs) or (
             hasattr(context, "pre_processors") and bool(context.pre_processors.get(self.dataset_name, []))
@@ -103,17 +104,6 @@ class DatasetInput(Input):
                 LOG.warning(msg)
                 warnings.warn(msg, UserWarning, stacklevel=2)
 
-        self.use_trajectories = use_trajectories
-
-        if not len(self.ds.shape) == 5 and self.use_trajectories:
-            raise ValueError(
-                f"Expected dataset with 5 dimensions (base_dates, variables, ensembles, steps, cells) as a trajectory dataset, got {len(self.ds.shape)} dimensions. Is this a trajectory dataset?"
-            )
-        elif len(self.ds.shape) == 5 and not self.use_trajectories:
-            raise ValueError(
-                f"Expected dataset with 4 dimensions (base_dates, variables, ensembles, cells) as a non-trajectory dataset, got {len(self.ds.shape)} dimensions. Is this a trajectory dataset?"
-            )
-
     @cached_property
     def ds(self) -> Any:
         """Return the dataset."""
@@ -127,6 +117,14 @@ class DatasetInput(Input):
         if self.variables is not None:
             dataset = open_dataset(dataset, select=self.variables)
 
+        if not len(dataset.shape) == 5 and self.use_trajectories:
+            raise ValueError(
+                f"Expected dataset with 5 dimensions (base_dates, variables, ensembles, steps, cells) as a trajectory dataset, got {len(self.ds.shape)} dimensions. Is this a trajectory dataset?"
+            )
+        elif len(dataset.shape) == 5 and not self.use_trajectories:
+            raise ValueError(
+                f"Expected dataset with 4 dimensions (base_dates, variables, ensembles, cells) as a non-trajectory dataset, got {len(self.ds.shape)} dimensions. Is this a trajectory dataset?"
+            )
         return dataset
 
     @cached_property

--- a/tests/unit/inputs/test_dataset_dates.py
+++ b/tests/unit/inputs/test_dataset_dates.py
@@ -1,0 +1,283 @@
+# (C) Copyright 2026- Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Unit tests for the dates logic in DatasetInput.
+
+Tests exercise `create_input_state` and `load_forcings_state` -- the
+public API -- to verify that the correct date slices are loaded from
+the underlying dataset.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import PropertyMock
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from anemoi.inference.inputs.dataset import DatasetInput
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+VARS = ["t", "u", "v"]
+_DATES = np.array(
+    [
+        np.datetime64("2024-01-01T00:00"),
+        np.datetime64("2024-01-01T06:00"),
+        np.datetime64("2024-01-01T12:00"),
+        np.datetime64("2024-01-01T18:00"),
+        np.datetime64("2024-01-02T00:00"),
+    ]
+)
+N_DATES = len(_DATES)
+N_VARS = len(VARS)
+N_ENS = 1
+N_CELLS = 10
+N_STEPS = 4
+
+# ---------------------------------------------------------------------------
+# Mock dataset
+# ---------------------------------------------------------------------------
+
+
+class _MockDataset:
+    """Minimal mock that behaves like an anemoi dataset."""
+
+    def __init__(self, data, *, has_base_dates=False):
+        self._data = data
+        self.shape = data.shape
+        self.dates = _DATES
+        self.frequency = np.timedelta64(6, "h")
+        self.latitudes = np.linspace(-90, 90, N_CELLS)
+        self.longitudes = np.linspace(0, 360, N_CELLS)
+        self.variables = list(VARS)
+        self.typed_variables = {v: SimpleNamespace(is_constant=False) for v in VARS}
+        self.name_to_index = {v: i for i, v in enumerate(VARS)}
+
+        if has_base_dates:
+            self.base_dates = _DATES
+            self.step_frequency = np.timedelta64(6, "h")
+
+    def __getitem__(self, key):
+        return self._data[key]
+
+
+def _make_4d_data():
+    return np.arange(N_DATES * N_VARS * N_ENS * N_CELLS, dtype=float).reshape(N_DATES, N_VARS, N_ENS, N_CELLS)
+
+
+def _make_5d_data():
+    return np.arange(N_DATES * N_VARS * N_ENS * N_STEPS * N_CELLS, dtype=float).reshape(
+        N_DATES, N_VARS, N_ENS, N_STEPS, N_CELLS
+    )
+
+
+# ---------------------------------------------------------------------------
+# Mock context / metadata
+# ---------------------------------------------------------------------------
+
+_TRACE = SimpleNamespace(from_input=lambda *a, **k: None)
+_HANDLER = SimpleNamespace(trace=_TRACE)
+
+
+def _make_ctx():
+    return SimpleNamespace(
+        verbosity=0,
+        reference_date=None,
+        tensor_handlers={"test_dataset": _HANDLER},
+    )
+
+
+def _make_meta(*, lagged=None):
+    """Build mock metadata.
+
+    lagged: list of timedelta offsets for lagged inputs (e.g. [0, -6h]).
+            Defaults to a single lag of 0.
+    """
+    if lagged is None:
+        lagged = [np.timedelta64(0, "h")]
+    return SimpleNamespace(
+        dataset_name="test_dataset",
+        _supporting_arrays={},
+        lagged=lagged,
+        variable_to_input_tensor_index={v: i for i, v in enumerate(VARS)},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helper to build a DatasetInput with the mock dataset injected
+# ---------------------------------------------------------------------------
+
+
+def _make_input(mock_ds, **extra_kwargs):
+    """Construct a DatasetInput with *ds* patched to *mock_ds*."""
+    ctx = _make_ctx()
+    meta = _make_meta(**extra_kwargs.pop("meta_kwargs", {}))
+    kwargs = dict(variables=list(VARS), open_dataset_args=(), open_dataset_kwargs={})
+    kwargs.update(extra_kwargs)
+
+    with patch.object(DatasetInput, "ds", new_callable=PropertyMock, return_value=mock_ds):
+        inp = DatasetInput(ctx, meta, **kwargs)
+    # Inject the mock into the instance dict so the cached_property descriptor
+    # is bypassed on subsequent accesses without polluting the class.
+    inp.__dict__["ds"] = mock_ds
+    return inp
+
+
+# ===================================================================
+# 4D (analysis) tests -- these should pass on both old and new code
+# ===================================================================
+
+
+class TestCreateInputState4D:
+    """Test create_input_state with a standard 4D dataset."""
+
+    def test_returns_correct_fields_for_date(self):
+        """Fields should contain data from the requested date."""
+        data = _make_4d_data()
+        ds = _MockDataset(data)
+        inp = _make_input(ds)
+
+        date = _DATES[2]
+        state = inp.create_input_state(date=date)
+
+        for vi, var in enumerate(VARS):
+            # shape: (n_lagged, n_cells) -- single lag of 0, no ensemble dim
+            expected = data[2, vi, 0, :]
+            np.testing.assert_array_equal(state["fields"][var], expected.reshape(1, N_CELLS))
+
+    def test_lagged_dates(self):
+        """With lagged offsets the correct date slices should be loaded."""
+        data = _make_4d_data()
+        ds = _MockDataset(data)
+        # lag -6h then 0  =>  date-6h then date (ascending order)
+        lags = [np.timedelta64(-6, "h"), np.timedelta64(0, "h")]
+        inp = _make_input(ds, meta_kwargs=dict(lagged=lags))
+
+        date = _DATES[2]  # 2024-01-01T12:00
+        state = inp.create_input_state(date=date)
+
+        for vi, var in enumerate(VARS):
+            # Two lagged dates: index 1 (T06) and index 2 (T12)
+            expected = np.stack([data[1, vi, 0, :], data[2, vi, 0, :]], axis=0)
+            np.testing.assert_array_equal(state["fields"][var], expected)
+
+    def test_constant_loads_single_date(self):
+        """constant=True should load only the requested date (no lags)."""
+        data = _make_4d_data()
+        ds = _MockDataset(data)
+        lags = [np.timedelta64(0, "h"), np.timedelta64(-6, "h")]
+        inp = _make_input(ds, meta_kwargs=dict(lagged=lags))
+
+        date = _DATES[3]
+        state = inp.create_input_state(date=date, constant=True)
+
+        for vi, var in enumerate(VARS):
+            expected = data[3, vi, 0, :].reshape(1, N_CELLS)
+            np.testing.assert_array_equal(state["fields"][var], expected)
+
+    def test_date_not_in_dataset_raises(self):
+        """Requesting a date outside the dataset should raise ValueError."""
+        ds = _MockDataset(_make_4d_data())
+        inp = _make_input(ds)
+        with pytest.raises(ValueError, match="not found"):
+            inp.create_input_state(date=np.datetime64("2099-01-01"))
+
+
+class TestLoadForcingsState4D:
+    """Test load_forcings_state with a standard 4D dataset."""
+
+    def test_single_date(self):
+        data = _make_4d_data()
+        ds = _MockDataset(data)
+        inp = _make_input(ds)
+
+        dates = [_DATES[1]]
+        current_state = {"date": _DATES[1], "step": np.timedelta64(0, "h")}
+        state = inp.load_forcings_state(dates=dates, current_state=current_state)
+
+        # Result shape per variable: (n_dates, n_cells)
+        for vi, var in enumerate(VARS):
+            expected = data[1, vi, 0, :].reshape(1, N_CELLS)
+            np.testing.assert_array_equal(state["fields"][var], expected)
+
+    def test_multiple_consecutive_dates(self):
+        data = _make_4d_data()
+        ds = _MockDataset(data)
+        inp = _make_input(ds)
+
+        dates = [_DATES[1], _DATES[2], _DATES[3]]
+        current_state = {"date": _DATES[1], "step": np.timedelta64(0, "h")}
+        state = inp.load_forcings_state(dates=dates, current_state=current_state)
+
+        for vi, var in enumerate(VARS):
+            expected = data[1:4, vi, 0, :]
+            np.testing.assert_array_equal(state["fields"][var], expected)
+
+
+# ===================================================================
+# 5D (trajectory) tests
+# ===================================================================
+
+
+class TestCreateInputState5D:
+    """Test create_input_state with a 5D trajectory dataset."""
+
+    def test_returns_step0_for_base_date(self):
+        """At the base date itself, step 0 data should be returned."""
+        data = _make_5d_data()
+        ds = _MockDataset(data, has_base_dates=True)
+        inp = _make_input(ds, use_trajectories=True)
+
+        date = _DATES[0]
+        state = inp.create_input_state(date=date)
+
+        for vi, var in enumerate(VARS):
+            expected = data[0, vi, 0, 0, :].reshape(1, N_CELLS)
+            np.testing.assert_array_equal(state["fields"][var], expected)
+
+
+class TestLoadForcingsState5D:
+    """Test load_forcings_state with a 5D trajectory dataset."""
+
+    def test_dates_after_base_use_trajectory(self):
+        """Dates beyond the base date should be read from the trajectory dimension."""
+        data = _make_5d_data()
+        ds = _MockDataset(data, has_base_dates=True)
+        inp = _make_input(ds, use_trajectories=True)
+
+        base_date = _DATES[0]
+        # Request 6h and 12h after base -> steps 1, 2
+        dates = [
+            base_date + np.timedelta64(6, "h"),
+            base_date + np.timedelta64(12, "h"),
+        ]
+        current_state = {"date": base_date, "step": np.timedelta64(0, "h")}
+        state = inp.load_forcings_state(dates=dates, current_state=current_state)
+
+        for vi, var in enumerate(VARS):
+            expected = data[0, vi, 0, 1:3, :]  # steps 1 and 2
+            np.testing.assert_array_equal(state["fields"][var], expected)
+
+    def test_dates_before_base_use_step0(self):
+        """Dates <= base should each be loaded at step 0 of their own base date."""
+        data = _make_5d_data()
+        ds = _MockDataset(data, has_base_dates=True)
+        inp = _make_input(ds, use_trajectories=True)
+
+        base_date = _DATES[2]
+        dates = [_DATES[0], _DATES[1]]
+        current_state = {"date": base_date, "step": np.timedelta64(0, "h")}
+        state = inp.load_forcings_state(dates=dates, current_state=current_state)
+
+        for vi, var in enumerate(VARS):
+            expected = np.stack([data[0, vi, 0, 0, :], data[1, vi, 0, 0, :]], axis=0)
+            np.testing.assert_array_equal(state["fields"][var], expected)


### PR DESCRIPTION
Adds `use_trajectories` support to `DatasetInput`, allowing trajectory datasets (5D: base_dates, variables, ensembles, steps, cells) to be used as inputs.

Resolves #529 
- [x] Validated on a real checkpoint and ds

```yaml
checkpoint: CKPT
date: 2023-01-02

input: validation

dynamic_forcings:
  dataset: 
    dataset: Trajectory.zarr
    use_trajectories: true
```

### Changes
- `DatasetInput` accepts `use_trajectories=True` to enable trajectory mode
- `_load_trajectories` loads data by indexing into the step dimension relative to a base date
- Uses `step_frequency` and `base_dates` (appropriate for trajectory datasets) instead of `frequency` and `dates`
- Transposes trajectory data to match the expected `(dates, variables, ensemble, cells)` shape

<!-- readthedocs-preview anemoi-inference start -->
----
📚 Documentation preview 📚: https://anemoi-inference--530.org.readthedocs.build/en/530/

<!-- readthedocs-preview anemoi-inference end -->