### PR TITLE
fix(parallel output): Support parallel grib archive requests

### DIFF
--- a/src/anemoi/inference/decorators.py
+++ b/src/anemoi/inference/decorators.py
@@ -101,10 +101,13 @@ class supports_parallel_output:
     When ParallelOutput spawns writers it passes ``_parallel-output-suffix="_w0"`` etc.
     This decorator turns ``path="out.grib"`` into ``path="out_w0.grib"``.
     If no ``_parallel-output-suffix`` is present in kwargs, the class is instantiated unchanged.
+
+    The path arg can also be a dot-notation string to support nested dictionaries, e.g. ``"archive_requests.path"``,
+    and multiple path args can be specified.
     """
 
-    def __init__(self, arg: str):
-        self.arg = arg
+    def __init__(self, *args: str):
+        self.args = args
 
     @staticmethod
     def add_suffix_to_path(val: Any, suffix: str) -> Any:
@@ -133,8 +136,8 @@ class supports_parallel_output:
             return val
 
     def __call__(self, cls: F) -> F:
-        # if not isinstance(cls, type):
-        #    raise TypeError(f"`{self.__class__.__name__}` can only be used to decorate classes")
+        if not isinstance(cls, type):
+            raise TypeError(f"`{self.__class__.__name__}` can only be used to decorate classes")
 
         class WrappedClass(cls):
             _supports_parallel_output = True
@@ -146,10 +149,21 @@ class supports_parallel_output:
                         f"Expected '_parallel-output-suffix' to be a string, got {type(parallel_output_suffix)}."
                     )
 
-                if parallel_output_suffix and self.arg in kwargs and kwargs[self.arg] is not None:
-                    kwargs[self.arg] = supports_parallel_output.add_suffix_to_path(
-                        kwargs[self.arg], parallel_output_suffix
-                    )
+                if parallel_output_suffix:
+                    for arg in self.args:
+                        # traverse the (possibly nested) path, bailing out silently if a level is missing
+                        container = kwargs
+                        *parents, leaf = arg.split(".")
+                        for key in parents:
+                            if not isinstance(container, dict) or key not in container:
+                                container = None
+                                break
+                            container = container[key]
+
+                        if isinstance(container, dict) and container.get(leaf) is not None:
+                            container[leaf] = supports_parallel_output.add_suffix_to_path(
+                                container[leaf], parallel_output_suffix
+                            )
 
                 super().__init__(*args, **kwargs)
 

--- a/src/anemoi/inference/outputs/gribfile.py
+++ b/src/anemoi/inference/outputs/gribfile.py
@@ -342,7 +342,7 @@ class GribIoOutput(BaseGribOutput):
 @output_registry.register("grib")
 @main_argument("path")
 @format_dataset_name("path")
-@supports_parallel_output("path")
+@supports_parallel_output("path", "archive_requests.path")
 @ensure_path("path")
 class GribFileOutput(GribIoOutput):
     """Handles grib files."""

--- a/tests/unit/outputs/parallel.py
+++ b/tests/unit/outputs/parallel.py
@@ -554,3 +554,57 @@ class TestSupportsParallelOutputDecorator:
                 pass
 
         assert getattr(_O, "_supports_parallel_output", False)
+
+    def _make_nested_cls(self, *paths):
+        @supports_parallel_output(*paths)
+        class _Output:
+            def __init__(self, path=None, archive_requests=None, **kwargs):
+                self.path = path
+                self.archive_requests = archive_requests
+
+        return _Output
+
+    def test_nested_suffix_applied(self):
+        obj = self._make_nested_cls("archive_requests.path")(
+            archive_requests={"path": "out.json"}, **{"_parallel-output-suffix": "_w0"}
+        )
+        assert obj.archive_requests["path"] == "out_w0.json"
+
+    def test_multiple_args_applied(self):
+        obj = self._make_nested_cls("path", "archive_requests.path")(
+            path="out.grib", archive_requests={"path": "out.json"}, **{"_parallel-output-suffix": "_w0"}
+        )
+        assert obj.path == "out_w0.grib"
+        assert obj.archive_requests["path"] == "out_w0.json"
+
+    def test_deep_nested_suffix_applied(self):
+        obj = self._make_nested_cls("archive_requests.sub.path")(
+            archive_requests={"sub": {"path": "out.json"}}, **{"_parallel-output-suffix": "_w0"}
+        )
+        assert obj.archive_requests["sub"]["path"] == "out_w0.json"
+
+    def test_nested_no_suffix_unchanged(self):
+        obj = self._make_nested_cls("archive_requests.path")(archive_requests={"path": "out.json"})
+        assert obj.archive_requests["path"] == "out.json"
+
+    def test_nested_missing_leaf_key_ignored(self):
+        obj = self._make_nested_cls("archive_requests.path")(
+            archive_requests={"other": "value"}, **{"_parallel-output-suffix": "_w0"}
+        )
+        assert obj.archive_requests == {"other": "value"}
+
+    def test_nested_missing_parent_key_ignored(self):
+        obj = self._make_nested_cls("archive_requests.path")(**{"_parallel-output-suffix": "_w0"})
+        assert obj.archive_requests is None
+
+    def test_nested_parent_not_dict_ignored(self):
+        obj = self._make_nested_cls("archive_requests.path")(
+            archive_requests="not-a-dict", **{"_parallel-output-suffix": "_w0"}
+        )
+        assert obj.archive_requests == "not-a-dict"
+
+    def test_nested_leaf_none_not_modified(self):
+        obj = self._make_nested_cls("archive_requests.path")(
+            archive_requests={"path": None}, **{"_parallel-output-suffix": "_w0"}
+        )
+        assert obj.archive_requests["path"] is None

--- a/tests/unit/outputs/test_parallel.py
+++ b/tests/unit/outputs/test_parallel.py
@@ -514,20 +514,21 @@ class TestAddSuffixToPath:
 
 
 class TestSupportsParallelOutputDecorator:
-    def _make_cls(self):
-        @supports_parallel_output("path")
+    def _make_cls(self, *args):
+        @supports_parallel_output(*args)
         class _Output:
-            def __init__(self, context, metadata, *, path=None, **kwargs):
+            def __init__(self, *, path=None, archive_requests=None, **kwargs):
                 self.path = path
+                self.archive_requests = archive_requests
 
         return _Output
 
     def test_suffix_applied(self):
-        obj = self._make_cls()("ctx", "meta", path="out.grib", **{"_parallel-output-suffix": "_w0"})
+        obj = self._make_cls("path")(path="out.grib", **{"_parallel-output-suffix": "_w0"})
         assert obj.path == "out_w0.grib"
 
     def test_no_suffix_unchanged(self):
-        obj = self._make_cls()("ctx", "meta", path="out.grib")
+        obj = self._make_cls("path")(path="out.grib")
         assert obj.path == "out.grib"
 
     def test_suffix_consumed_not_forwarded(self):
@@ -540,12 +541,12 @@ class TestSupportsParallelOutputDecorator:
         assert "_parallel-output-suffix" not in obj.kw
 
     def test_none_path_not_modified(self):
-        obj = self._make_cls()("ctx", "meta", path=None, **{"_parallel-output-suffix": "_w0"})
+        obj = self._make_cls("path")(path=None, **{"_parallel-output-suffix": "_w0"})
         assert obj.path is None
 
     def test_invalid_suffix_type_raises(self):
         with pytest.raises(ValueError, match="_parallel-output-suffix"):
-            self._make_cls()("ctx", "meta", path="out.grib", **{"_parallel-output-suffix": 42})
+            self._make_cls("path")(path="out.grib", **{"_parallel-output-suffix": 42})
 
     def test_marks_class_attribute(self):
         @supports_parallel_output("path")
@@ -555,56 +556,47 @@ class TestSupportsParallelOutputDecorator:
 
         assert getattr(_O, "_supports_parallel_output", False)
 
-    def _make_nested_cls(self, *paths):
-        @supports_parallel_output(*paths)
-        class _Output:
-            def __init__(self, path=None, archive_requests=None, **kwargs):
-                self.path = path
-                self.archive_requests = archive_requests
-
-        return _Output
-
     def test_nested_suffix_applied(self):
-        obj = self._make_nested_cls("archive_requests.path")(
+        obj = self._make_cls("archive_requests.path")(
             archive_requests={"path": "out.json"}, **{"_parallel-output-suffix": "_w0"}
         )
         assert obj.archive_requests["path"] == "out_w0.json"
 
     def test_multiple_args_applied(self):
-        obj = self._make_nested_cls("path", "archive_requests.path")(
+        obj = self._make_cls("path", "archive_requests.path")(
             path="out.grib", archive_requests={"path": "out.json"}, **{"_parallel-output-suffix": "_w0"}
         )
         assert obj.path == "out_w0.grib"
         assert obj.archive_requests["path"] == "out_w0.json"
 
     def test_deep_nested_suffix_applied(self):
-        obj = self._make_nested_cls("archive_requests.sub.path")(
+        obj = self._make_cls("archive_requests.sub.path")(
             archive_requests={"sub": {"path": "out.json"}}, **{"_parallel-output-suffix": "_w0"}
         )
         assert obj.archive_requests["sub"]["path"] == "out_w0.json"
 
     def test_nested_no_suffix_unchanged(self):
-        obj = self._make_nested_cls("archive_requests.path")(archive_requests={"path": "out.json"})
+        obj = self._make_cls("archive_requests.path")(archive_requests={"path": "out.json"})
         assert obj.archive_requests["path"] == "out.json"
 
     def test_nested_missing_leaf_key_ignored(self):
-        obj = self._make_nested_cls("archive_requests.path")(
+        obj = self._make_cls("archive_requests.path")(
             archive_requests={"other": "value"}, **{"_parallel-output-suffix": "_w0"}
         )
         assert obj.archive_requests == {"other": "value"}
 
     def test_nested_missing_parent_key_ignored(self):
-        obj = self._make_nested_cls("archive_requests.path")(**{"_parallel-output-suffix": "_w0"})
+        obj = self._make_cls("archive_requests.path")(**{"_parallel-output-suffix": "_w0"})
         assert obj.archive_requests is None
 
     def test_nested_parent_not_dict_ignored(self):
-        obj = self._make_nested_cls("archive_requests.path")(
+        obj = self._make_cls("archive_requests.path")(
             archive_requests="not-a-dict", **{"_parallel-output-suffix": "_w0"}
         )
         assert obj.archive_requests == "not-a-dict"
 
     def test_nested_leaf_none_not_modified(self):
-        obj = self._make_nested_cls("archive_requests.path")(
+        obj = self._make_cls("archive_requests.path")(
             archive_requests={"path": None}, **{"_parallel-output-suffix": "_w0"}
         )
         assert obj.archive_requests["path"] is None


### PR DESCRIPTION
## Description
For parallel grib output, we forgot about the archive requests. These also need to have the suffix attached so a unique file is created by each writer.

Update the `supports_parallel_output` decorator so that it:

1. Can take multiple arguments, all of which will have the suffix attached
2. Supports dot notation for nested dictionaries, like `archive_requests.path`

Also rename the parallel unit test file to `test_parallel.py` for clarity.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
