### PR TITLE
fix(parallel output): grib input templates

### DIFF
--- a/src/anemoi/inference/grib/templates/input.py
+++ b/src/anemoi/inference/grib/templates/input.py
@@ -21,20 +21,6 @@ from .manager import TemplateManager
 LOG = logging.getLogger(__name__)
 
 
-class _GribHandleWrapper:
-    """Minimal wrapper around a GribCodesHandle so it satisfies the template.handle.clone() contract
-    expected by encode_message(), while being reconstructable from raw GRIB bytes."""
-
-    def __init__(self, handle: Any) -> None:
-        self.handle = handle
-
-    def metadata(self, key: str, default: Any = None) -> Any:
-        try:
-            return self.handle.get(key, default=default)
-        except Exception:
-            return default
-
-
 @template_provider_registry.register("input")
 class InputTemplates(TemplateProvider):
     """Use input fields as the output GRIB template."""
@@ -60,31 +46,6 @@ class InputTemplates(TemplateProvider):
             fallback = f"(fallback {fallback})"
         return info.format(fallback=fallback)
 
-    def _reconstruct_from_bytes(self, state: State, variable: str) -> "_GribHandleWrapper | None":
-        """Reconstruct a GRIB handle wrapper from serialised bytes stored in the state.
-
-        Used by parallel writer processes that receive raw GRIB bytes instead of live
-        earthkit Field objects. Reconstructed wrappers are cached back into
-        ``_grib_templates_for_output`` so subsequent calls for the same variable are instant.
-        """
-        bytes_templates = state.get("_grib_templates_bytes_for_output", {})
-        if variable not in bytes_templates:
-            return None
-
-        try:
-            import eccodes
-            from earthkit.data.readers.grib.codes import GribCodesHandle
-
-            h = eccodes.codes_new_from_message(bytes_templates[variable])
-            wrapper = _GribHandleWrapper(GribCodesHandle(h, None, None))
-        except Exception as e:
-            LOG.warning("Could not reconstruct GRIB template for '%s' from bytes: %s", variable, e)
-            return None
-
-        # Cache back so subsequent calls for the same variable skip reconstruction
-        state.setdefault("_grib_templates_for_output", {})[variable] = wrapper
-        return wrapper
-
     def template(
         self,
         variable: str,
@@ -96,13 +57,8 @@ class InputTemplates(TemplateProvider):
         if template := state.get("_grib_templates_for_output", {}).get(variable):
             return template
 
-        if template := self._reconstruct_from_bytes(state, variable):
-            return template
-
         if fallback_variable := self.fallback.get(variable):
             if template := state.get("_grib_templates_for_output", {}).get(fallback_variable):
-                return template
-            if template := self._reconstruct_from_bytes(state, fallback_variable):
                 return template
             LOG.warning(f"Fallback variable '{fallback_variable}' for output '{variable}' not found in input state.")
 

--- a/src/anemoi/inference/grib/templates/input.py
+++ b/src/anemoi/inference/grib/templates/input.py
@@ -21,6 +21,20 @@ from .manager import TemplateManager
 LOG = logging.getLogger(__name__)
 
 
+class _GribHandleWrapper:
+    """Minimal wrapper around a GribCodesHandle so it satisfies the template.handle.clone() contract
+    expected by encode_message(), while being reconstructable from raw GRIB bytes."""
+
+    def __init__(self, handle: Any) -> None:
+        self.handle = handle
+
+    def metadata(self, key: str, default: Any = None) -> Any:
+        try:
+            return self.handle.get(key, default=default)
+        except Exception:
+            return default
+
+
 @template_provider_registry.register("input")
 class InputTemplates(TemplateProvider):
     """Use input fields as the output GRIB template."""
@@ -46,6 +60,31 @@ class InputTemplates(TemplateProvider):
             fallback = f"(fallback {fallback})"
         return info.format(fallback=fallback)
 
+    def _reconstruct_from_bytes(self, state: State, variable: str) -> "_GribHandleWrapper | None":
+        """Reconstruct a GRIB handle wrapper from serialised bytes stored in the state.
+
+        Used by parallel writer processes that receive raw GRIB bytes instead of live
+        earthkit Field objects. Reconstructed wrappers are cached back into
+        ``_grib_templates_for_output`` so subsequent calls for the same variable are instant.
+        """
+        bytes_templates = state.get("_grib_templates_bytes_for_output", {})
+        if variable not in bytes_templates:
+            return None
+
+        try:
+            import eccodes
+            from earthkit.data.readers.grib.codes import GribCodesHandle
+
+            h = eccodes.codes_new_from_message(bytes_templates[variable])
+            wrapper = _GribHandleWrapper(GribCodesHandle(h, None, None))
+        except Exception as e:
+            LOG.warning("Could not reconstruct GRIB template for '%s' from bytes: %s", variable, e)
+            return None
+
+        # Cache back so subsequent calls for the same variable skip reconstruction
+        state.setdefault("_grib_templates_for_output", {})[variable] = wrapper
+        return wrapper
+
     def template(
         self,
         variable: str,
@@ -57,8 +96,13 @@ class InputTemplates(TemplateProvider):
         if template := state.get("_grib_templates_for_output", {}).get(variable):
             return template
 
+        if template := self._reconstruct_from_bytes(state, variable):
+            return template
+
         if fallback_variable := self.fallback.get(variable):
             if template := state.get("_grib_templates_for_output", {}).get(fallback_variable):
+                return template
+            if template := self._reconstruct_from_bytes(state, fallback_variable):
                 return template
             LOG.warning(f"Fallback variable '{fallback_variable}' for output '{variable}' not found in input state.")
 

--- a/src/anemoi/inference/outputs/parallel.py
+++ b/src/anemoi/inference/outputs/parallel.py
@@ -49,24 +49,6 @@ def _detach_tensors(obj: Any) -> Any:
     return obj
 
 
-class _GribHandleWrapper:
-    """Minimal wrapper around a ``GribCodesHandle`` reconstructed from raw GRIB bytes.
-
-    Satisfies the ``template.metadata(...)`` and ``template.handle.clone()`` contract
-    expected by the GRIB encoder, so the writer processes in :class:`ParallelOutput`
-    can consume templates that were shipped across the process boundary as bytes.
-    """
-
-    def __init__(self, handle: Any) -> None:
-        self.handle = handle
-
-    def metadata(self, key: str, default: Any = None) -> Any:
-        try:
-            return self.handle.get(key, default=default)
-        except Exception:
-            return default
-
-
 def _serialise_grib_templates(templates: dict) -> dict[str, bytes]:
     """Convert a dict of earthkit GRIB fields to a dict of raw GRIB bytes so they can be pickled."""
     result = {}
@@ -78,21 +60,21 @@ def _serialise_grib_templates(templates: dict) -> dict[str, bytes]:
     return result
 
 
-def _deserialise_grib_templates(bytes_templates: dict[str, bytes]) -> dict[str, "_GribHandleWrapper"]:
-    """Reconstruct wrapped GRIB handles from raw bytes.
+def _deserialise_grib_templates(bytes_templates: dict[str, bytes]) -> dict[str, Any]:
+    """Reconstruct earthkit GRIB fields from raw bytes.
 
-    Used inside writer processes to restore ``_grib_templates_for_output`` before
-    passing the state to the wrapped output. Failed reconstructions are skipped
-    with a warning so a single bad template does not abort the whole state.
+    Uses ``earthkit.data.from_source("memory", ...)`` so the writer processes see
+    the exact same field type they would see in the non-parallel path (i.e. the
+    field the input pipeline stored under ``_grib_templates_for_output``).
+    Failed reconstructions are skipped with a warning so a single bad template
+    does not abort the whole state.
     """
-    import eccodes
-    from earthkit.data.readers.grib.codes import GribCodesHandle
+    import earthkit.data as ekd
 
-    result: dict[str, _GribHandleWrapper] = {}
+    result: dict[str, Any] = {}
     for name, msg in bytes_templates.items():
         try:
-            h = eccodes.codes_new_from_message(msg)
-            result[name] = _GribHandleWrapper(GribCodesHandle(h, None, None))
+            result[name] = ekd.from_source("memory", msg)[0]
         except Exception as e:
             LOG.warning("Could not reconstruct GRIB template for '%s' from bytes: %s", name, e)
     return result

--- a/src/anemoi/inference/outputs/parallel.py
+++ b/src/anemoi/inference/outputs/parallel.py
@@ -49,14 +49,52 @@ def _detach_tensors(obj: Any) -> Any:
     return obj
 
 
+class _GribHandleWrapper:
+    """Minimal wrapper around a ``GribCodesHandle`` reconstructed from raw GRIB bytes.
+
+    Satisfies the ``template.metadata(...)`` and ``template.handle.clone()`` contract
+    expected by the GRIB encoder, so the writer processes in :class:`ParallelOutput`
+    can consume templates that were shipped across the process boundary as bytes.
+    """
+
+    def __init__(self, handle: Any) -> None:
+        self.handle = handle
+
+    def metadata(self, key: str, default: Any = None) -> Any:
+        try:
+            return self.handle.get(key, default=default)
+        except Exception:
+            return default
+
+
 def _serialise_grib_templates(templates: dict) -> dict[str, bytes]:
-    """Convert a dict of earthkit fields to a dict of raw GRIB bytes so they can be pickled."""
+    """Convert a dict of earthkit GRIB fields to a dict of raw GRIB bytes so they can be pickled."""
     result = {}
     for name, field in templates.items():
         try:
             result[name] = field.message()
         except Exception as e:
             LOG.warning("Could not serialise GRIB template for '%s': %s", name, e)
+    return result
+
+
+def _deserialise_grib_templates(bytes_templates: dict[str, bytes]) -> dict[str, "_GribHandleWrapper"]:
+    """Reconstruct wrapped GRIB handles from raw bytes.
+
+    Used inside writer processes to restore ``_grib_templates_for_output`` before
+    passing the state to the wrapped output. Failed reconstructions are skipped
+    with a warning so a single bad template does not abort the whole state.
+    """
+    import eccodes
+    from earthkit.data.readers.grib.codes import GribCodesHandle
+
+    result: dict[str, _GribHandleWrapper] = {}
+    for name, msg in bytes_templates.items():
+        try:
+            h = eccodes.codes_new_from_message(msg)
+            result[name] = _GribHandleWrapper(GribCodesHandle(h, None, None))
+        except Exception as e:
+            LOG.warning("Could not reconstruct GRIB template for '%s' from bytes: %s", name, e)
     return result
 
 
@@ -68,7 +106,8 @@ def _sanitise_state(state: State) -> State:
     state = state.copy()
 
     # Serialise GRIB templates to raw bytes so they survive pickling into writer processes.
-    # The writer reconstructs ekd.Field objects from these bytes via _grib_templates_bytes_for_output.
+    # The writer reconstructs ekd.Field-like objects from these bytes via
+    # _restore_grib_templates() before handing the state to the wrapped output.
     if (templates := state.get("_grib_templates_for_output")) is not None:
         state["_grib_templates_bytes_for_output"] = _serialise_grib_templates(templates)
         state.pop("_grib_templates_for_output")
@@ -79,6 +118,22 @@ def _sanitise_state(state: State) -> State:
             state.pop(key)
             LOG.debug("Removed unpicklable key '%s' from state before sending to writer process", key)
     return _detach_tensors(state)
+
+
+def _restore_grib_templates(state: State) -> State:
+    """Reverse of the GRIB-template step in :func:`_sanitise_state`.
+
+    Called inside writer processes so the wrapped output sees the same
+    ``_grib_templates_for_output`` layout it would in single-process mode.
+    No-op if the state does not carry serialised templates.
+    """
+    if not isinstance(state, dict):
+        return state
+    bytes_templates = state.pop("_grib_templates_bytes_for_output", None)
+    if not bytes_templates:
+        return state
+    state["_grib_templates_for_output"] = _deserialise_grib_templates(bytes_templates)
+    return state
 
 
 def _get_state_chunk(state: State, num_chunks: int, index: int) -> State:
@@ -310,12 +365,12 @@ class ParallelOutput(Output):
                     output.close()
                     break
                 elif message_type == MessageType.OPEN:
-                    output.open(message)
+                    output.open(_restore_grib_templates(message))
                 elif message_type == MessageType.INITIAL_STATE:
-                    output.write_initial_state(message)
+                    output.write_initial_state(_restore_grib_templates(message))
                 elif message_type == MessageType.STATE:
                     LOG.debug("Writer %d writing: %s", writer_id, message.get("date"))
-                    output.write_state(message)
+                    output.write_state(_restore_grib_templates(message))
                     LOG.debug("Writer %d done: %s", writer_id, message.get("date"))
                 else:
                     LOG.warning("Writer %d received message with unknown type '%s'", writer_id, message_type)

--- a/src/anemoi/inference/outputs/parallel.py
+++ b/src/anemoi/inference/outputs/parallel.py
@@ -49,8 +49,43 @@ def _detach_tensors(obj: Any) -> Any:
     return obj
 
 
+def _template_message_bytes(field: Any) -> bytes:
+    """Return the raw GRIB bytes of *field* stripped of its data section.
+
+    The writer only needs the template's metadata (grid, packing, product
+    definition); the values are discarded and overwritten. With this we can
+    reduce what crosses the fork boundary from hundreds of KB to ~200 B per
+    template by overwriting the values with zeros.
+
+    ``bitsPerValue`` is forced back to its original value after zeroing the
+    data section: eccodes otherwise resets it to the default (typically 24)
+    when the section is rewritten with a constant field, which would change
+    the packing of every message the writer produces vs. the non-parallel
+    path.
+
+    Falls back to :meth:`field.message` if the shrink cannot be applied.
+    """
+    import numpy as np
+
+    try:
+        handle = field.handle.clone()
+        bpv = handle.get("bitsPerValue")
+        n = int(handle.get("numberOfDataPoints"))
+        handle.set_values(np.zeros(n))
+        handle.set("bitsPerValue", bpv)
+        return handle.get_buffer()
+    except Exception as e:
+        LOG.debug("Could not strip data section from GRIB template: %s; sending full message.", e)
+        return field.message()
+
+
 def _serialise_grib_templates(templates: dict) -> dict[str, bytes]:
     """Convert a dict of earthkit GRIB fields to a dict of raw GRIB bytes so they can be pickled.
+
+    Each template is stripped of its data section before pickling (see
+    :func:`_template_message_bytes`) so the number of bytes shipped through the
+    multiprocessing queue is a few hundred per template instead of the full
+    field size.
 
     Templates that cannot be converted (e.g. non-GRIB fields, or future earthkit
     wrappers that do not expose ``.message()``) are skipped with a warning so a
@@ -61,7 +96,7 @@ def _serialise_grib_templates(templates: dict) -> dict[str, bytes]:
     result = {}
     for name, field in templates.items():
         try:
-            result[name] = field.message()
+            result[name] = _template_message_bytes(field)
         except Exception as e:
             LOG.warning(
                 "Could not serialise GRIB template for '%s' (type=%s): %s; skipping.",
@@ -93,20 +128,22 @@ def _deserialise_grib_templates(bytes_templates: dict[str, bytes]) -> dict[str, 
     return result
 
 
-def _sanitise_state(state: State) -> State:
-    """Remove private keys and convert tensors so the state is safe to pickle."""
+def _sanitise_state(state: State, grib_templates_bytes: dict[str, bytes] | None = None) -> State:
+    """Remove private keys and convert tensors so the state is safe to pickle.
+
+    ``grib_templates_bytes``, if provided, replaces ``_grib_templates_for_output``
+    on the returned state with the corresponding ``_grib_templates_bytes_for_output``
+    payload. Callers precompute this once per dispatch so we do not re-serialise the
+    same templates dict N times when there are N writers.
+    """
 
     unpicklable_keys = ["_input"]
 
     state = state.copy()
 
-    # Serialise GRIB templates to raw bytes so they survive pickling into writer processes.
-    # The writer reconstructs ekd.Field-like objects from these bytes via
-    # _restore_grib_templates() before handing the state to the wrapped output.
-    if (templates := state.get("_grib_templates_for_output")) is not None:
-        state["_grib_templates_bytes_for_output"] = _serialise_grib_templates(templates)
-        state.pop("_grib_templates_for_output")
-        LOG.debug("Serialised %d GRIB templates to bytes for writer process", len(templates))
+    if grib_templates_bytes is not None:
+        state["_grib_templates_bytes_for_output"] = grib_templates_bytes
+    state.pop("_grib_templates_for_output", None)
 
     for key in unpicklable_keys:
         if state.get(key) is not None:
@@ -238,6 +275,13 @@ class ParallelOutput(Output):
         # __init__ time the context may not yet have lead_time / time_step set.
         self._writers_running = False
 
+        # Cache of the serialised GRIB templates bytes-map, keyed by id() of the
+        # ``_grib_templates_for_output`` dict on the incoming state. Populated in
+        # dispatch_state_to_writers so we don't re-serialise once per writer
+        # (or once per rollout step, when the input pipeline reuses the same dict).
+        self._grib_templates_bytes_cache_key: int | None = None
+        self._grib_templates_bytes_cache_value: dict[str, bytes] | None = None
+
     def open(self, state: State) -> None:
         """Spawn the writer processes during open() instead of __init__() to ensure they have access to the full context.
 
@@ -274,10 +318,35 @@ class ParallelOutput(Output):
 
         Takes an optional 'message' argument to indicate the type of message being sent, which is used for control flow in the writer loop.
         """
+        grib_templates_bytes = self._get_or_serialise_grib_templates(state)
         for i in range(self.num_writers):
             self._check_writer_alive(i)
             chunk = _get_state_chunk(state, self.num_writers, i)
-            self._queues[i].put((_sanitise_state(chunk), message))
+            self._queues[i].put((_sanitise_state(chunk, grib_templates_bytes), message))
+
+    def _get_or_serialise_grib_templates(self, state: State) -> dict[str, bytes] | None:
+        """Return the serialised GRIB templates bytes-map, serialising it on the first call.
+
+        Result is memoised on the instance and keyed by ``id()`` of the
+        ``_grib_templates_for_output`` dict: as long as the input pipeline hands
+        us the same dict object across dispatches, we serialise once and reuse
+        the bytes for every writer and every subsequent step. When the pipeline
+        replaces the dict (e.g. the set of templates changes), the id() mismatch
+        forces a fresh serialisation.
+
+        Returns None if the state has no GRIB templates to send.
+        """
+        templates = state.get("_grib_templates_for_output")
+        if templates is None:
+            return None
+        key = id(templates)
+        if key == self._grib_templates_bytes_cache_key:
+            return self._grib_templates_bytes_cache_value
+        bytes_map = _serialise_grib_templates(templates)
+        LOG.debug("Serialised %d GRIB templates to bytes for writer processes", len(bytes_map))
+        self._grib_templates_bytes_cache_key = key
+        self._grib_templates_bytes_cache_value = bytes_map
+        return bytes_map
 
     def close(self) -> None:
         """Terminate writer processes, then close the wrapped output."""

--- a/src/anemoi/inference/outputs/parallel.py
+++ b/src/anemoi/inference/outputs/parallel.py
@@ -49,12 +49,31 @@ def _detach_tensors(obj: Any) -> Any:
     return obj
 
 
+def _serialise_grib_templates(templates: dict) -> dict[str, bytes]:
+    """Convert a dict of earthkit fields to a dict of raw GRIB bytes so they can be pickled."""
+    result = {}
+    for name, field in templates.items():
+        try:
+            result[name] = field.message()
+        except Exception as e:
+            LOG.warning("Could not serialise GRIB template for '%s': %s", name, e)
+    return result
+
+
 def _sanitise_state(state: State) -> State:
     """Remove private keys and convert tensors so the state is safe to pickle."""
 
-    unpicklable_keys = ["_grib_templates_for_output", "_input"]
+    unpicklable_keys = ["_input"]
 
     state = state.copy()
+
+    # Serialise GRIB templates to raw bytes so they survive pickling into writer processes.
+    # The writer reconstructs ekd.Field objects from these bytes via _grib_templates_bytes_for_output.
+    if (templates := state.get("_grib_templates_for_output")) is not None:
+        state["_grib_templates_bytes_for_output"] = _serialise_grib_templates(templates)
+        state.pop("_grib_templates_for_output")
+        LOG.debug("Serialised %d GRIB templates to bytes for writer process", len(templates))
+
     for key in unpicklable_keys:
         if state.get(key) is not None:
             state.pop(key)

--- a/tests/unit/test_templates.py
+++ b/tests/unit/test_templates.py
@@ -271,7 +271,8 @@ def test_sanitise_state_bytes_are_picklable():
 
 def test_restore_grib_templates_reconstructs_wrapper(mocker: MockerFixture):
     """_restore_grib_templates turns serialised bytes back into a usable handle wrapper,
-    which InputTemplates can then serve without any bytes-awareness of its own."""
+    which InputTemplates can then serve without any bytes-awareness of its own.
+    """
     field = _make_grib_field_mock("2t", bits_per_value=16)
     state = {"_grib_templates_for_output": {"2t": field}, "fields": {}}
     sanitised = _sanitise_state(state)

--- a/tests/unit/test_templates.py
+++ b/tests/unit/test_templates.py
@@ -27,7 +27,6 @@ from anemoi.inference.grib.encoding import grib_keys
 from anemoi.inference.grib.templates.input import InputTemplates
 from anemoi.inference.grib.templates.manager import TemplateManager
 from anemoi.inference.metadata import Metadata
-from anemoi.inference.outputs.parallel import _GribHandleWrapper
 from anemoi.inference.outputs.parallel import _restore_grib_templates
 from anemoi.inference.outputs.parallel import _sanitise_state
 from anemoi.inference.testing import files_for_tests
@@ -270,7 +269,7 @@ def test_sanitise_state_bytes_are_picklable():
 
 
 def test_restore_grib_templates_reconstructs_wrapper(mocker: MockerFixture):
-    """_restore_grib_templates turns serialised bytes back into a usable handle wrapper,
+    """_restore_grib_templates turns serialised bytes back into a real GribField,
     which InputTemplates can then serve without any bytes-awareness of its own."""
     field = _make_grib_field_mock("2t", bits_per_value=16)
     state = {"_grib_templates_for_output": {"2t": field}, "fields": {}}
@@ -286,7 +285,7 @@ def test_restore_grib_templates_reconstructs_wrapper(mocker: MockerFixture):
 
     template = provider.template("2t", {}, state=restored)
 
-    assert isinstance(template, _GribHandleWrapper)
+    assert isinstance(template, GribField)
     assert template.metadata("shortName") == "2t"
     assert template.metadata("bitsPerValue") == 16
 
@@ -324,7 +323,7 @@ def test_restore_grib_templates_populates_cache():
 
 
 def test_restore_grib_templates_handle_is_cloneable():
-    """The restored wrapper's handle can be cloned — required by encode_message."""
+    """The restored field's handle can be cloned — required by encode_message."""
     field = _make_grib_field_mock("2t", bits_per_value=16)
     state = {"_grib_templates_for_output": {"2t": field}, "fields": {}}
     restored = _restore_grib_templates(_sanitise_state(state))

--- a/tests/unit/test_templates.py
+++ b/tests/unit/test_templates.py
@@ -11,7 +11,6 @@ import json
 from datetime import datetime
 from pathlib import Path
 
-import eccodes
 import pytest
 import yaml
 from anemoi.utils.testing import GetTestData
@@ -29,6 +28,7 @@ from anemoi.inference.grib.templates.manager import TemplateManager
 from anemoi.inference.metadata import Metadata
 from anemoi.inference.outputs.parallel import _restore_grib_templates
 from anemoi.inference.outputs.parallel import _sanitise_state
+from anemoi.inference.outputs.parallel import _serialise_grib_templates
 from anemoi.inference.testing import files_for_tests
 
 
@@ -231,11 +231,10 @@ def test_builtin_gribwriter(manager, variable, tmp_path):
 
 def _make_grib_field_mock(short_name: str, bits_per_value: int) -> object:
     """Create a minimal mock field whose .message() returns real GRIB bytes."""
-    raw = eccodes.codes_grib_new_from_samples("regular_ll_sfc_grib2")
-    eccodes.codes_set(raw, "shortName", short_name)
-    eccodes.codes_set(raw, "bitsPerValue", bits_per_value)
-    msg = eccodes.codes_get_message(raw)
-    eccodes.codes_release(raw)
+    handle = GribCodesHandle.from_sample("regular_ll_sfc_grib2")
+    handle.set("shortName", short_name)
+    handle.set("bitsPerValue", bits_per_value)
+    msg = handle.get_buffer()
 
     class _MockField:
         def message(self):
@@ -244,12 +243,19 @@ def _make_grib_field_mock(short_name: str, bits_per_value: int) -> object:
     return _MockField()
 
 
+def _sanitise_with_templates(state: dict) -> dict:
+    """Test helper: mimic ParallelOutput.dispatch by pre-serialising templates."""
+    templates = state.get("_grib_templates_for_output")
+    bytes_map = _serialise_grib_templates(templates) if templates is not None else None
+    return _sanitise_state(state, bytes_map)
+
+
 def test_sanitise_state_serialises_grib_templates():
     """_sanitise_state converts _grib_templates_for_output to picklable bytes."""
     field = _make_grib_field_mock("2t", bits_per_value=16)
     state = {"_grib_templates_for_output": {"2t": field}, "fields": {}}
 
-    sanitised = _sanitise_state(state)
+    sanitised = _sanitise_with_templates(state)
 
     assert "_grib_templates_for_output" not in sanitised
     assert "_grib_templates_bytes_for_output" in sanitised
@@ -262,7 +268,7 @@ def test_sanitise_state_bytes_are_picklable():
 
     field = _make_grib_field_mock("2t", bits_per_value=16)
     state = {"_grib_templates_for_output": {"2t": field}, "fields": {}}
-    sanitised = _sanitise_state(state)
+    sanitised = _sanitise_with_templates(state)
 
     restored = pickle.loads(pickle.dumps(sanitised))
     assert isinstance(restored["_grib_templates_bytes_for_output"]["2t"], bytes)
@@ -274,7 +280,7 @@ def test_restore_grib_templates_reconstructs_wrapper(mocker: MockerFixture):
     """
     field = _make_grib_field_mock("2t", bits_per_value=16)
     state = {"_grib_templates_for_output": {"2t": field}, "fields": {}}
-    sanitised = _sanitise_state(state)
+    sanitised = _sanitise_with_templates(state)
     restored = _restore_grib_templates(sanitised)
 
     assert "_grib_templates_bytes_for_output" not in restored
@@ -296,7 +302,7 @@ def test_restore_grib_templates_preserves_bits_per_value(mocker: MockerFixture):
     for bpv in (16, 24):
         field = _make_grib_field_mock("2t", bits_per_value=bpv)
         state = {"_grib_templates_for_output": {"2t": field}, "fields": {}}
-        restored = _restore_grib_templates(_sanitise_state(state))
+        restored = _restore_grib_templates(_sanitise_with_templates(state))
 
         owner = mocker.MagicMock()
         owner.metadata = _metadata()
@@ -314,11 +320,42 @@ def test_restore_grib_templates_noop_without_bytes():
     assert "_grib_templates_bytes_for_output" not in restored
 
 
+def test_template_bytes_are_cached_across_calls():
+    """ParallelOutput._get_or_serialise_grib_templates caches on templates-dict identity."""
+    from anemoi.inference.outputs import parallel as parallel_mod
+
+    field = _make_grib_field_mock("2t", bits_per_value=16)
+    templates = {"2t": field}
+    state = {"_grib_templates_for_output": templates, "fields": {}}
+
+    calls = {"n": 0}
+    orig = parallel_mod._serialise_grib_templates
+
+    def spy(t):
+        calls["n"] += 1
+        return orig(t)
+
+    # Build a minimal ParallelOutput just to exercise its cache method
+    po = parallel_mod.ParallelOutput.__new__(parallel_mod.ParallelOutput)
+    po._grib_templates_bytes_cache_key = None
+    po._grib_templates_bytes_cache_value = None
+
+    parallel_mod._serialise_grib_templates = spy
+    try:
+        b1 = po._get_or_serialise_grib_templates(state)
+        b2 = po._get_or_serialise_grib_templates(state)
+    finally:
+        parallel_mod._serialise_grib_templates = orig
+
+    assert b1 is b2
+    assert calls["n"] == 1
+
+
 def test_restore_grib_templates_populates_cache():
     """After restore, _grib_templates_for_output is populated on the state."""
     field = _make_grib_field_mock("2t", bits_per_value=16)
     state = {"_grib_templates_for_output": {"2t": field}, "fields": {}}
-    restored = _restore_grib_templates(_sanitise_state(state))
+    restored = _restore_grib_templates(_sanitise_with_templates(state))
 
     assert "2t" in restored.get("_grib_templates_for_output", {})
 
@@ -327,10 +364,167 @@ def test_restore_grib_templates_handle_is_cloneable():
     """The restored field's handle can be cloned — required by encode_message."""
     field = _make_grib_field_mock("2t", bits_per_value=16)
     state = {"_grib_templates_for_output": {"2t": field}, "fields": {}}
-    restored = _restore_grib_templates(_sanitise_state(state))
+    restored = _restore_grib_templates(_sanitise_with_templates(state))
 
     template = restored["_grib_templates_for_output"]["2t"]
     cloned = template.handle.clone()
 
     assert isinstance(cloned, GribCodesHandle)
-    assert eccodes.codes_get(cloned._handle, "bitsPerValue") == 16
+    assert cloned.get("bitsPerValue") == 16
+
+
+def _make_ekd_field(short_name: str, bits_per_value: int, param_id: int | None = None):
+    """Build a real ekd GribField (same type ParallelOutput sees at runtime)."""
+    import earthkit.data as ekd
+
+    handle = GribCodesHandle.from_sample("regular_ll_sfc_grib2")
+    handle.set("shortName", short_name)
+    handle.set("bitsPerValue", bits_per_value)
+    if param_id is not None:
+        handle.set("paramId", param_id)
+    return ekd.from_source("memory", handle.get_buffer())[0]
+
+
+def _encode_with_template(field, values) -> bytes:
+    """Encode the given values through the template's handle, mirroring what the writer does.
+
+    The writer inherits ``bitsPerValue`` (and other packing settings) from the template
+    rather than setting them explicitly, so we do the same here — this makes the test
+    sensitive to any regression that drops packing metadata from the parallel-path
+    template.
+    """
+    import numpy as np
+
+    handle = field.handle.clone()
+    handle.set_values(np.asarray(values, dtype=float))
+    return handle.get_buffer()
+
+
+@pytest.mark.parametrize("bpv", [16, 24])
+def test_parallel_and_normal_paths_encode_identically_with_templates(bpv):
+    """Round-trip: parallel path (sanitise → pickle → restore) yields templates that
+    encode to the same GRIB bytes as the normal path for the same input values.
+
+    This is the unit-level analogue of the full parallel/non-parallel byte-equal check:
+    it isolates the template serialisation and asserts that a writer using the
+    restored template would produce byte-identical output.
+    """
+    import pickle
+
+    import numpy as np
+
+    field_a = _make_ekd_field("2t", bits_per_value=bpv, param_id=167)
+    field_b = _make_ekd_field("2t", bits_per_value=bpv, param_id=167)  # separate handle, same content
+
+    # Normal path uses field_a directly.
+    # Parallel path takes field_b through sanitise + pickle + restore.
+    state = {"_grib_templates_for_output": {"2t": field_b}, "fields": {}}
+    sanitised = _sanitise_state(state, _serialise_grib_templates(state["_grib_templates_for_output"]))
+    restored = _restore_grib_templates(pickle.loads(pickle.dumps(sanitised)))
+    field_b_restored = restored["_grib_templates_for_output"]["2t"]
+
+    # Product-definition metadata (independent of the stripped data section) must match.
+    for key in ("shortName", "numberOfDataPoints", "Ni", "Nj", "paramId"):
+        assert field_a.metadata(key) == field_b_restored.metadata(key), f"mismatch on {key}"
+
+    # Encoding the same values through both handles must yield identical bytes:
+    # this is the invariant that guarantees the writer produces the same output
+    # regardless of the parallel/non-parallel path. In particular, the restored
+    # template must preserve ``bitsPerValue`` — if it doesn't, eccodes falls
+    # back to a default and every message the writer produces will be packed
+    # differently from the reference.
+    n = int(field_a.handle.get("numberOfDataPoints"))
+    values = np.linspace(240.0, 310.0, n)
+    assert _encode_with_template(field_a, values) == _encode_with_template(field_b_restored, values)
+
+
+def test_parallel_and_normal_paths_agree_without_templates():
+    """Round-trip: a state without GRIB templates comes back equal (modulo private keys)
+    through the parallel sanitise/restore path.
+    """
+    import pickle
+
+    import numpy as np
+
+    state = {
+        "fields": {"2t": np.arange(6, dtype=float)},
+        "date": datetime(2024, 1, 1),
+        "_input": object(),  # private, should be stripped by _sanitise_state
+    }
+
+    sanitised = _sanitise_state(state, None)
+    restored = _restore_grib_templates(pickle.loads(pickle.dumps(sanitised)))
+
+    assert "_input" not in restored
+    assert "_grib_templates_for_output" not in restored
+    assert "_grib_templates_bytes_for_output" not in restored
+    assert restored["date"] == state["date"]
+    np.testing.assert_array_equal(restored["fields"]["2t"], state["fields"]["2t"])
+
+
+@pytest.mark.parametrize("with_templates", [True, False])
+def test_parallel_roundtrip_preserves_input_transformation(with_templates: bool):
+    """A user-supplied input transformation (gh → z) must survive the parallel-runner cross-process pipeline —
+    ``_sanitise_state`` → pickle → ``_restore_grib_templates`` — both with and
+    without GRIB templates attached to the state.
+    """
+    import pickle
+
+    import earthkit.data as ekd
+    import numpy as np
+
+    from anemoi.inference.outputs.parallel import _serialise_grib_templates
+
+    levels = [500, 850]
+    rng = np.random.default_rng(0)
+    n = int(GribCodesHandle.from_sample("regular_ll_sfc_grib2").get("numberOfDataPoints"))
+
+    def make_template(short_name: str) -> ekd.Field:
+        h = GribCodesHandle.from_sample("regular_ll_sfc_grib2")
+        h.set("shortName", short_name)
+        h.set("bitsPerValue", 16)
+        return ekd.from_source("memory", h.get_buffer())[0]
+
+    # Build a "raw open-data" state with gh fields (and optional templates).
+    state: dict = {
+        "date": datetime(2024, 1, 1),
+        "fields": {f"gh_{lvl}": rng.uniform(5000.0, 6000.0, n) for lvl in levels},
+    }
+    if with_templates:
+        state["_grib_templates_for_output"] = {f"gh_{lvl}": make_template("gh") for lvl in levels}
+
+    # Apply the gh → z transformation on the main process side.
+    g = 9.80665
+    for lvl in levels:
+        state["fields"][f"z_{lvl}"] = state["fields"].pop(f"gh_{lvl}") * g
+        if with_templates:
+            tmpl = state["_grib_templates_for_output"].pop(f"gh_{lvl}")
+            h = tmpl.handle.clone()
+            h.set("shortName", "z")
+            state["_grib_templates_for_output"][f"z_{lvl}"] = ekd.from_source(
+                "memory", h.get_buffer()
+            )[0]
+
+    # Push through the exact machinery ParallelOutput.dispatch_state_to_writers uses.
+    templates = state.get("_grib_templates_for_output")
+    bytes_map = _serialise_grib_templates(templates) if templates else None
+    sanitised = _sanitise_state(state, bytes_map)
+    restored = _restore_grib_templates(pickle.loads(pickle.dumps(sanitised)))
+
+    # Field values must arrive on the writer side unchanged.
+    assert sorted(restored["fields"]) == sorted(state["fields"])
+    for k, v in state["fields"].items():
+        np.testing.assert_array_equal(restored["fields"][k], v)
+
+    if with_templates:
+        # Templates must survive: shortName preserved, and encoding the transformed
+        # values through the round-tripped template gives the same GRIB bytes as
+        # through the original template (the writer's byte-exactness invariant).
+        for name, orig in templates.items():
+            rt = restored["_grib_templates_for_output"][name]
+            assert rt.metadata("shortName") == orig.metadata("shortName") == "z"
+            values = state["fields"][name]
+            assert _encode_with_template(orig, values) == _encode_with_template(rt, values)
+    else:
+        assert "_grib_templates_for_output" not in restored
+        assert "_grib_templates_bytes_for_output" not in restored

--- a/tests/unit/test_templates.py
+++ b/tests/unit/test_templates.py
@@ -11,9 +11,11 @@ import json
 from datetime import datetime
 from pathlib import Path
 
+import eccodes
 import pytest
 import yaml
 from anemoi.utils.testing import GetTestData
+from earthkit.data.readers.grib.codes import GribCodesHandle
 from earthkit.data.readers.grib.codes import GribField
 from earthkit.data.utils.dates import to_timedelta
 from pytest_mock import MockerFixture
@@ -22,8 +24,11 @@ from rich import print
 from anemoi.inference.grib.encoding import GribWriter
 from anemoi.inference.grib.encoding import check_encoding
 from anemoi.inference.grib.encoding import grib_keys
+from anemoi.inference.grib.templates.input import InputTemplates
+from anemoi.inference.grib.templates.input import _GribHandleWrapper
 from anemoi.inference.grib.templates.manager import TemplateManager
 from anemoi.inference.metadata import Metadata
+from anemoi.inference.outputs.parallel import _sanitise_state
 from anemoi.inference.testing import files_for_tests
 
 
@@ -219,3 +224,109 @@ def test_builtin_gribwriter(manager, variable, tmp_path):
         handle, _ = output.write(values=None, template=template, metadata=metadata)
         check_encoding(handle, metadata)
         output.close()
+
+
+# ── Parallel output: GRIB template serialisation / reconstruction ────────────
+
+
+def _make_grib_field_mock(short_name: str, bits_per_value: int) -> object:
+    """Create a minimal mock field whose .message() returns real GRIB bytes."""
+    raw = eccodes.codes_grib_new_from_samples("regular_ll_sfc_grib2")
+    eccodes.codes_set(raw, "shortName", short_name)
+    eccodes.codes_set(raw, "bitsPerValue", bits_per_value)
+    msg = eccodes.codes_get_message(raw)
+    eccodes.codes_release(raw)
+
+    class _MockField:
+        def message(self):
+            return msg
+
+    return _MockField()
+
+
+def test_sanitise_state_serialises_grib_templates():
+    """_sanitise_state converts _grib_templates_for_output to picklable bytes."""
+    field = _make_grib_field_mock("2t", bits_per_value=16)
+    state = {"_grib_templates_for_output": {"2t": field}, "fields": {}}
+
+    sanitised = _sanitise_state(state)
+
+    assert "_grib_templates_for_output" not in sanitised
+    assert "_grib_templates_bytes_for_output" in sanitised
+    assert isinstance(sanitised["_grib_templates_bytes_for_output"]["2t"], bytes)
+
+
+def test_sanitise_state_bytes_are_picklable():
+    """Bytes produced by _sanitise_state survive a pickle round-trip."""
+    import pickle
+
+    field = _make_grib_field_mock("2t", bits_per_value=16)
+    state = {"_grib_templates_for_output": {"2t": field}, "fields": {}}
+    sanitised = _sanitise_state(state)
+
+    restored = pickle.loads(pickle.dumps(sanitised))
+    assert isinstance(restored["_grib_templates_bytes_for_output"]["2t"], bytes)
+
+
+def test_input_templates_reconstruct_from_bytes(mocker: MockerFixture):
+    """InputTemplates falls back to bytes and reconstructs a usable handle wrapper."""
+    field = _make_grib_field_mock("2t", bits_per_value=16)
+    state = {"_grib_templates_for_output": {"2t": field}, "fields": {}}
+    sanitised = _sanitise_state(state)
+
+    owner = mocker.MagicMock()
+    owner.metadata = _metadata()
+    provider = InputTemplates(owner)
+
+    template = provider.template("2t", {}, state=sanitised)
+
+    assert isinstance(template, _GribHandleWrapper)
+    assert template.metadata("shortName") == "2t"
+    assert template.metadata("bitsPerValue") == 16
+
+
+def test_input_templates_reconstruct_preserves_bits_per_value(mocker: MockerFixture):
+    """Reconstructed template preserves the original bitsPerValue so packing is identical."""
+    for bpv in (16, 24):
+        field = _make_grib_field_mock("2t", bits_per_value=bpv)
+        state = {"_grib_templates_for_output": {"2t": field}, "fields": {}}
+        sanitised = _sanitise_state(state)
+
+        owner = mocker.MagicMock()
+        owner.metadata = _metadata()
+        provider = InputTemplates(owner)
+
+        template = provider.template("2t", {}, state=sanitised)
+        assert template.metadata("bitsPerValue") == bpv, f"expected bpv={bpv}"
+
+
+def test_input_templates_reconstruct_caches_result(mocker: MockerFixture):
+    """After reconstruction, the wrapper is cached in _grib_templates_for_output."""
+    field = _make_grib_field_mock("2t", bits_per_value=16)
+    state = {"_grib_templates_for_output": {"2t": field}, "fields": {}}
+    sanitised = _sanitise_state(state)
+
+    owner = mocker.MagicMock()
+    owner.metadata = _metadata()
+    provider = InputTemplates(owner)
+
+    provider.template("2t", {}, state=sanitised)
+
+    assert "2t" in sanitised.get("_grib_templates_for_output", {})
+
+
+def test_input_templates_reconstructed_handle_is_cloneable(mocker: MockerFixture):
+    """The reconstructed wrapper's handle can be cloned — required by encode_message."""
+    field = _make_grib_field_mock("2t", bits_per_value=16)
+    state = {"_grib_templates_for_output": {"2t": field}, "fields": {}}
+    sanitised = _sanitise_state(state)
+
+    owner = mocker.MagicMock()
+    owner.metadata = _metadata()
+    provider = InputTemplates(owner)
+
+    template = provider.template("2t", {}, state=sanitised)
+    cloned = template.handle.clone()
+
+    assert isinstance(cloned, GribCodesHandle)
+    assert eccodes.codes_get(cloned._handle, "bitsPerValue") == 16

--- a/tests/unit/test_templates.py
+++ b/tests/unit/test_templates.py
@@ -501,9 +501,7 @@ def test_parallel_roundtrip_preserves_input_transformation(with_templates: bool)
             tmpl = state["_grib_templates_for_output"].pop(f"gh_{lvl}")
             h = tmpl.handle.clone()
             h.set("shortName", "z")
-            state["_grib_templates_for_output"][f"z_{lvl}"] = ekd.from_source(
-                "memory", h.get_buffer()
-            )[0]
+            state["_grib_templates_for_output"][f"z_{lvl}"] = ekd.from_source("memory", h.get_buffer())[0]
 
     # Push through the exact machinery ParallelOutput.dispatch_state_to_writers uses.
     templates = state.get("_grib_templates_for_output")

--- a/tests/unit/test_templates.py
+++ b/tests/unit/test_templates.py
@@ -270,7 +270,8 @@ def test_sanitise_state_bytes_are_picklable():
 
 def test_restore_grib_templates_reconstructs_wrapper(mocker: MockerFixture):
     """_restore_grib_templates turns serialised bytes back into a real GribField,
-    which InputTemplates can then serve without any bytes-awareness of its own."""
+    which InputTemplates can then serve without any bytes-awareness of its own.
+    """
     field = _make_grib_field_mock("2t", bits_per_value=16)
     state = {"_grib_templates_for_output": {"2t": field}, "fields": {}}
     sanitised = _sanitise_state(state)

--- a/tests/unit/test_templates.py
+++ b/tests/unit/test_templates.py
@@ -25,9 +25,10 @@ from anemoi.inference.grib.encoding import GribWriter
 from anemoi.inference.grib.encoding import check_encoding
 from anemoi.inference.grib.encoding import grib_keys
 from anemoi.inference.grib.templates.input import InputTemplates
-from anemoi.inference.grib.templates.input import _GribHandleWrapper
 from anemoi.inference.grib.templates.manager import TemplateManager
 from anemoi.inference.metadata import Metadata
+from anemoi.inference.outputs.parallel import _GribHandleWrapper
+from anemoi.inference.outputs.parallel import _restore_grib_templates
 from anemoi.inference.outputs.parallel import _sanitise_state
 from anemoi.inference.testing import files_for_tests
 
@@ -268,64 +269,67 @@ def test_sanitise_state_bytes_are_picklable():
     assert isinstance(restored["_grib_templates_bytes_for_output"]["2t"], bytes)
 
 
-def test_input_templates_reconstruct_from_bytes(mocker: MockerFixture):
-    """InputTemplates falls back to bytes and reconstructs a usable handle wrapper."""
+def test_restore_grib_templates_reconstructs_wrapper(mocker: MockerFixture):
+    """_restore_grib_templates turns serialised bytes back into a usable handle wrapper,
+    which InputTemplates can then serve without any bytes-awareness of its own."""
     field = _make_grib_field_mock("2t", bits_per_value=16)
     state = {"_grib_templates_for_output": {"2t": field}, "fields": {}}
     sanitised = _sanitise_state(state)
+    restored = _restore_grib_templates(sanitised)
+
+    assert "_grib_templates_bytes_for_output" not in restored
+    assert "_grib_templates_for_output" in restored
 
     owner = mocker.MagicMock()
     owner.metadata = _metadata()
     provider = InputTemplates(owner)
 
-    template = provider.template("2t", {}, state=sanitised)
+    template = provider.template("2t", {}, state=restored)
 
     assert isinstance(template, _GribHandleWrapper)
     assert template.metadata("shortName") == "2t"
     assert template.metadata("bitsPerValue") == 16
 
 
-def test_input_templates_reconstruct_preserves_bits_per_value(mocker: MockerFixture):
+def test_restore_grib_templates_preserves_bits_per_value(mocker: MockerFixture):
     """Reconstructed template preserves the original bitsPerValue so packing is identical."""
     for bpv in (16, 24):
         field = _make_grib_field_mock("2t", bits_per_value=bpv)
         state = {"_grib_templates_for_output": {"2t": field}, "fields": {}}
-        sanitised = _sanitise_state(state)
+        restored = _restore_grib_templates(_sanitise_state(state))
 
         owner = mocker.MagicMock()
         owner.metadata = _metadata()
         provider = InputTemplates(owner)
 
-        template = provider.template("2t", {}, state=sanitised)
+        template = provider.template("2t", {}, state=restored)
         assert template.metadata("bitsPerValue") == bpv, f"expected bpv={bpv}"
 
 
-def test_input_templates_reconstruct_caches_result(mocker: MockerFixture):
-    """After reconstruction, the wrapper is cached in _grib_templates_for_output."""
+def test_restore_grib_templates_noop_without_bytes():
+    """_restore_grib_templates leaves states without serialised templates untouched."""
+    state = {"fields": {}}
+    restored = _restore_grib_templates(state)
+    assert "_grib_templates_for_output" not in restored
+    assert "_grib_templates_bytes_for_output" not in restored
+
+
+def test_restore_grib_templates_populates_cache():
+    """After restore, _grib_templates_for_output is populated on the state."""
     field = _make_grib_field_mock("2t", bits_per_value=16)
     state = {"_grib_templates_for_output": {"2t": field}, "fields": {}}
-    sanitised = _sanitise_state(state)
+    restored = _restore_grib_templates(_sanitise_state(state))
 
-    owner = mocker.MagicMock()
-    owner.metadata = _metadata()
-    provider = InputTemplates(owner)
-
-    provider.template("2t", {}, state=sanitised)
-
-    assert "2t" in sanitised.get("_grib_templates_for_output", {})
+    assert "2t" in restored.get("_grib_templates_for_output", {})
 
 
-def test_input_templates_reconstructed_handle_is_cloneable(mocker: MockerFixture):
-    """The reconstructed wrapper's handle can be cloned — required by encode_message."""
+def test_restore_grib_templates_handle_is_cloneable():
+    """The restored wrapper's handle can be cloned — required by encode_message."""
     field = _make_grib_field_mock("2t", bits_per_value=16)
     state = {"_grib_templates_for_output": {"2t": field}, "fields": {}}
-    sanitised = _sanitise_state(state)
+    restored = _restore_grib_templates(_sanitise_state(state))
 
-    owner = mocker.MagicMock()
-    owner.metadata = _metadata()
-    provider = InputTemplates(owner)
-
-    template = provider.template("2t", {}, state=sanitised)
+    template = restored["_grib_templates_for_output"]["2t"]
     cloned = template.handle.clone()
 
     assert isinstance(cloned, GribCodesHandle)


### PR DESCRIPTION
## Description
This PR is to update the ParallelOutput runner to correctly carry the GRIB templates to writer processes. 
- The templates are earthkit Field objects wrapping live handles, which can't be pickled and previously had to be dropped from the state. 
- Now, inside ``_sanitise_state``, each template is serialised to raw GRIB bytes and stored unde5``_grib_templates_bytes_for_output``;
-  Then the writer loop calls a new ``_restore_grib_templates``helper that turns those bytes back into a tiny ``_GribHandleWrapper`` and puts them back under the usual ``_grib_templates_for_output`` key before handing the state to the wrapped output. 
- All of this lives entirely in ``parallel.py`` so the rest of the codebase are unchanged from main and only the parallel path is affected.

Unit-tests are added too!

## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
