### PR TITLE
fix: invalid use of units config 

### DIFF
--- a/src/anemoi/inference/inputs/dataset.py
+++ b/src/anemoi/inference/inputs/dataset.py
@@ -296,7 +296,7 @@ class DatasetInputArgsKwargs(DatasetInput):
         """
 
         check_variables_compatibility = multi_datasets_config(
-            context.config.check_variables_compatibility, metadata.dataset_name, context.dataset_names
+            context.config.check_variables_compatibility, metadata.dataset_name, context.dataset_names, strict=False
         )
 
         if not args and not kwargs:

--- a/src/anemoi/inference/runner.py
+++ b/src/anemoi/inference/runner.py
@@ -908,7 +908,9 @@ class Runner(Context):
         checkpoint_variables = {k: v for k, v in checkpoint_variables.items() if k in common}
         state_variables = {k: v for k, v in state_variables.items() if k in common}
 
-        config = multi_datasets_config(self.config.check_variables_compatibility, dataset, self.dataset_names)
+        config = multi_datasets_config(
+            self.config.check_variables_compatibility, dataset, self.dataset_names, strict=False
+        )
         if config is None:
             config = {}
 


### PR DESCRIPTION
## Description
Units config was using strict=true causing breaks when run with single dataset models

#513 introduced a new config option, but was used incorrectly.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
