### PR TITLE
fix(temporal downscaler): do not squeeze time dimension

### DIFF
--- a/src/anemoi/inference/runners/temporal_downscaler.py
+++ b/src/anemoi/inference/runners/temporal_downscaler.py
@@ -321,7 +321,10 @@ class TemporalDownscalerMultiOutRunner(Runner):
 
                     # Detach tensor and squeeze (should we detach here?)
                     with ProfilingLabel("Sending output to cpu", self.use_profiler):
-                        output = np.squeeze(y_pred[dataset].cpu().numpy())  # shape: (values, variables)
+                        # squeeze batch and ensemble dims of tensor with shape: (batch, steps, ensemble, values, variables)
+                        output = np.squeeze(
+                            y_pred[dataset].cpu().numpy(), axis=(0, 2)
+                        )  # shape: (steps, values, variables)
 
                     if handler.trace:
                         handler.trace.write_output_tensor(


### PR DESCRIPTION
## Description
Fix the temporal downscaler runner to work with checkpoints for which the time dimension (`steps`) in the output is 1. I have confirmed it runs a dummy checkpoint created with:
```
  input_timestep: 6h
  output_timestep: 3h
  output_right_boundary: False
```

## What issue or task does this change relate to?
https://github.com/ecmwf/anemoi-inference/issues/544


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
