### PR TITLE
fix(parallel output): Convert num_writers to integer before validation

### DIFF
--- a/src/anemoi/inference/outputs/parallel.py
+++ b/src/anemoi/inference/outputs/parallel.py
@@ -257,7 +257,7 @@ class ParallelOutput(Output):
             metadata,
         )
 
-        self.num_writers = num_writers
+        self.num_writers = int(num_writers)
         if self.num_writers < 1:
             raise ValueError("num_writers must be at least 1")
 


### PR DESCRIPTION
## Description
Coerce `num_writers` to int before validation, allowing for env vars to be used in the configuration of the output parallel.


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
