### PR TITLE
feat(inputs): Add opendap input source

### DIFF
--- a/docs/inference/configs/inputs.rst
+++ b/docs/inference/configs/inputs.rst
@@ -121,6 +121,42 @@ file.
       )
       ds_xr.to_netcdf("input.nc")
 
+*********
+ opendap
+*********
+
+You can specify the input as ``opendap`` to read the data from a remote
+`OpenDAP <https://www.opendap.org/>`_ server, such as a `THREDDS Data
+Server <https://www.unidata.ucar.edu/software/tds/>`_. Under the hood
+this uses `earthkit-data`'s ``opendap`` source.
+
+.. literalinclude:: yaml/inputs_opendap_1.yaml
+   :language: yaml
+
+The URL can be given directly (as above), or under the ``url`` key so
+that additional options can be provided.
+
+The URL may contain Python format strings, which are resolved
+dynamically for the date of each retrieval. The ``date`` variable is
+made available, so you can use `strftime
+<https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes>`_
+format codes to construct the URL:
+
+.. literalinclude:: yaml/inputs_opendap_2.yaml
+   :language: yaml
+
+A list of URLs can also be provided, in which case the data from each is
+retrieved and combined. This is useful when different variables (e.g.
+surface and pressure levels) are served from separate files:
+
+.. literalinclude:: yaml/inputs_opendap_3.yaml
+   :language: yaml
+
+.. note::
+
+   If the retrieved data contains multiple valid datetimes, only the
+   first one is used and a warning is emitted.
+
 ******
  mars
 ******

--- a/docs/inference/configs/yaml/inputs_opendap_1.yaml
+++ b/docs/inference/configs/yaml/inputs_opendap_1.yaml
@@ -1,0 +1,2 @@
+input:
+  opendap: https://thredds.example.com/thredds/dodsC/det_sfc.nc

--- a/docs/inference/configs/yaml/inputs_opendap_2.yaml
+++ b/docs/inference/configs/yaml/inputs_opendap_2.yaml
@@ -1,0 +1,3 @@
+input:
+  opendap:
+    url: https://thredds.example.com/thredds/dodsC/{date:%Y}/{date:%m}/{date:%d}/det_sfc_{date:%Y%m%d}T{date:%H}Z.nc

--- a/docs/inference/configs/yaml/inputs_opendap_3.yaml
+++ b/docs/inference/configs/yaml/inputs_opendap_3.yaml
@@ -1,0 +1,5 @@
+input:
+  opendap:
+    url:
+      - https://thredds.example.com/thredds/dodsC/{date:%Y}/{date:%m}/{date:%d}/det_sfc_{date:%Y%m%d}T{date:%H}Z.nc
+      - https://thredds.example.com/thredds/dodsC/{date:%Y}/{date:%m}/{date:%d}/det_pl_{date:%Y%m%d}T{date:%H}Z.nc

--- a/src/anemoi/inference/inputs/opendap.py
+++ b/src/anemoi/inference/inputs/opendap.py
@@ -51,7 +51,11 @@ class OpenDAPInput(EkdInput):
         url: str | list[str]
             The URL or list of URL's of the OpenDAP file / server.
             Python format strings can be used to dynamically construct the URL, with the following variables available:
-            - {date} : The date for which the input is being created.
+            - {date:...} : The date for which the input is being created.
+
+            It is expected that a user formats any variable correctly for the OpenDAP server, e.g. using strftime format codes for dates.
+            i.e.: .../thredds/{date:%Y}/{date:%m}/{date:%d}/det_sfc_{date:%Y%m%d}T{date:%H}Z.nc
+            for dates, if no format string is provided, the default format is isoformat, e.g. 2023-01-01 00:00:00.
         """
         super().__init__(context, metadata, **kwargs)
         self.url = url if isinstance(url, list) else [url]

--- a/src/anemoi/inference/inputs/opendap.py
+++ b/src/anemoi/inference/inputs/opendap.py
@@ -1,0 +1,135 @@
+# (C) Copyright 2026- Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import logging
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from ..context import Context
+from ..decorators import main_argument
+from ..metadata import Metadata
+from ..types import Date
+from ..types import State
+from . import input_registry
+from .ekd import EkdInput
+
+LOG = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    import earthkit.data as ekd
+
+
+@input_registry.register("opendap")
+@main_argument("url")
+class OpenDAPInput(EkdInput):
+    """Handles OpenDAP sourced files."""
+
+    trace_name = "OpenDAP file"
+
+    def __init__(
+        self,
+        context: Context,
+        metadata: Metadata,
+        *,
+        url: str | list[str],
+        **kwargs,
+    ) -> None:
+        """Initialise the OpenDAPInput.
+
+        Parameters
+        ----------
+        context : Any
+            The context in which the input is used.
+        url: str | list[str]
+            The URL or list of URL's of the OpenDAP file / server.
+            Python format strings can be used to dynamically construct the URL, with the following variables available:
+            - {date} : The date for which the input is being created.
+        """
+        super().__init__(context, metadata, **kwargs)
+        self.url = url if isinstance(url, list) else [url]
+
+    def _resolve_url(self, date: Date | None) -> list[str]:
+        """Resolve the URL for the given date."""
+        if date is None:
+            if any("{date" in u for u in self.url):
+                raise ValueError("Date must be provided to resolve the URL.")
+            return self.url
+        return [u.format(date=date) for u in self.url]
+
+    def _retrieve_from_opendap(self, resolved_url: list[str]) -> "ekd.FieldList":
+        """Retrieve the data from the OpenDAP server, filtering to the first valid_datetime if multiple present."""
+        import earthkit.data as ekd
+
+        retrieved_data = [ekd.from_source("opendap", url) for url in resolved_url]
+        combined_fieldlist = ekd.FieldList.from_fields([f for fl in retrieved_data for f in fl])  # type: ignore[reportGeneralTypeIssues]
+        if len(combined_fieldlist.unique_values("valid_datetime")["valid_datetime"]) > 1:
+            LOG.warning(
+                f"Retrieved data from OpenDAP server has multiple valid_datetimes: {combined_fieldlist.unique_values('valid_datetime')}. Using the first one."
+            )
+            combined_fieldlist = combined_fieldlist.isel(valid_datetime=0)
+        return combined_fieldlist  # type: ignore[reportReturnType]
+
+    def create_input_state(self, *, date: Date | None, ref_date_index: int = -1, **kwargs) -> State:
+        """Create the input state for the given date.
+
+        Parameters
+        ----------
+        date : Optional[Date]
+            The date for which to create the input state.
+        ref_date_index : int = -1
+            If 0 takes the first date, if -1 takes the last date in sequence.
+        **kwargs : Any
+            Additional keyword arguments.
+
+        Returns
+        -------
+        State
+            The created input state.
+        """
+        import earthkit.data as ekd
+
+        date = np.datetime64(date).astype(datetime)
+        dates = [date + h for h in self.metadata.lagged]
+
+        fieldlists = []
+
+        for d in dates:
+            resolved_url = self._resolve_url(d)
+            LOG.info(f"Retrieving data for input_state from OpenDAP server: {resolved_url}")
+            fieldlists.append(self._retrieve_from_opendap(resolved_url))
+
+        fieldlist = ekd.FieldList.from_fields([f for fl in fieldlists for f in fl])
+        return self._create_input_state(fieldlist, date=date, ref_date_index=ref_date_index, **kwargs)
+
+    def load_forcings_state(self, *, dates: list[Date], current_state: State) -> State:
+        """Load the forcings state for the given variables and dates.
+
+        Parameters
+        ----------
+        dates : List[Date]
+            List of dates for which to load the forcings.
+        current_state : State
+            The current state of the input.
+
+        Returns
+        -------
+        State
+            The loaded forcings state.
+        """
+        fieldlists = []
+
+        for d in dates:
+            resolved_url = self._resolve_url(d)
+            LOG.info(f"Retrieving data for forcings from OpenDAP server: {resolved_url}")
+            fieldlists.append(self._retrieve_from_opendap(resolved_url))
+
+        fieldlist = ekd.FieldList.from_fields([f for fl in fieldlists for f in fl])
+        return self._load_forcings_state(fieldlist, dates=dates, current_state=current_state)

--- a/src/anemoi/inference/inputs/split.py
+++ b/src/anemoi/inference/inputs/split.py
@@ -58,15 +58,15 @@ class SplitInput(Input):
             vars = set(vars)
 
             if not set(vars) <= all_variables:
-                raise ValueError(
-                    f"Variables {vars} not in the provided variables {all_variables} ({set(vars) - all_variables})"
+                LOG.warning(
+                    f"Variables {vars} requested additional field to the model requested variables {all_variables} ({set(vars) - all_variables})"
                 )
 
             self.splits[tuple(sorted(vars))] = create_input(
                 context,
                 s["source"],
                 metadata,
-                variables=vars,
+                variables=list(vars),
                 purpose=s.get("purpose"),
             )
 
@@ -75,9 +75,9 @@ class SplitInput(Input):
         all_variables -= seen
 
         for i, vars1 in enumerate(splits):
-            vars1 = set(vars1)
+            vars1 = set(vars1["variables"])
             for j, vars2 in enumerate(splits):
-                vars2 = set(vars2)
+                vars2 = set(vars2["variables"])
                 if i == j:
                     continue
                 if not vars1.isdisjoint(vars2):
@@ -124,8 +124,6 @@ class SplitInput(Input):
 
         state = combine_states(*states)
 
-        assert set(state["fields"]) == set(self.variables), (sorted(state["fields"]), sorted(self.variables))
-
         state["_input"] = self
         state["date"] = date
 
@@ -150,8 +148,6 @@ class SplitInput(Input):
 
         states = [split.load_forcings_state(dates=dates, current_state=current_state) for split in self.splits]
         state = combine_states(*states)
-
-        assert set(state["fields"]) == set(self.variables)
 
         state["date"] = dates[-1]
         state["_input"] = self

--- a/src/anemoi/inference/inputs/split.py
+++ b/src/anemoi/inference/inputs/split.py
@@ -44,7 +44,7 @@ class SplitInput(Input):
             assert isinstance(s, dict), "each split must be a dictionary"
 
             if "default" in s:
-                default = s["default"]
+                default = s["source"]
                 continue
 
             assert "source" in s, "each split must have a 'source' key"
@@ -75,9 +75,9 @@ class SplitInput(Input):
         all_variables -= seen
 
         for i, vars1 in enumerate(splits):
-            vars1 = set(vars1["variables"])
+            vars1 = set(vars1.get("variables", []))
             for j, vars2 in enumerate(splits):
-                vars2 = set(vars2["variables"])
+                vars2 = set(vars2.get("variables", []))
                 if i == j:
                     continue
                 if not vars1.isdisjoint(vars2):
@@ -92,7 +92,7 @@ class SplitInput(Input):
             self.splits[tuple(sorted(all_variables))] = create_input(
                 context,
                 default,
-                self.metadata,
+                metadata,
                 variables=sorted(all_variables),
                 purpose=kwargs.get("purpose"),
             )

--- a/src/anemoi/inference/inputs/split.py
+++ b/src/anemoi/inference/inputs/split.py
@@ -58,9 +58,12 @@ class SplitInput(Input):
             vars = set(vars)
 
             if not set(vars) <= all_variables:
-                LOG.warning(
-                    f"Variables {vars} requested additional field to the model requested variables {all_variables} ({set(vars) - all_variables})"
-                )
+                LOG.warning(f"Variables {vars} in split {s} are not in the requested variables {all_variables}")
+                vars = all_variables & vars
+
+            if not vars:
+                LOG.warning(f"No valid variables in split {s}, skipping")
+                continue
 
             self.splits[tuple(sorted(vars))] = create_input(
                 context,
@@ -97,8 +100,6 @@ class SplitInput(Input):
                 purpose=kwargs.get("purpose"),
             )
 
-        assert len(self.splits) > 1, "At least two splits must be provided"
-
         self.splits = list(self.splits.values())
 
         super().__init__(context, metadata, **kwargs)
@@ -122,7 +123,10 @@ class SplitInput(Input):
         # TODO: Consider caching the result
         states = [split.create_input_state(date=date, **kwargs) for split in self.splits]
 
-        state = combine_states(*states)
+        if len(states) == 1:
+            state = states[0]
+        else:
+            state = combine_states(*states)
 
         state["_input"] = self
         state["date"] = date
@@ -147,7 +151,10 @@ class SplitInput(Input):
         assert len(dates) > 0, "dates must not be empty for repeated dates input"
 
         states = [split.load_forcings_state(dates=dates, current_state=current_state) for split in self.splits]
-        state = combine_states(*states)
+        if len(states) == 1:
+            state = states[0]
+        else:
+            state = combine_states(*states)
 
         state["date"] = dates[-1]
         state["_input"] = self


### PR DESCRIPTION
## Description
Add opendap input source using earthkit data source.

```yaml
input: 
	opendap: URL_GOES_HERE_{date}
```

## What problem does this change solve?
Allows for integrations with opendap and thredds servers


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)


<!-- readthedocs-preview anemoi-inference start -->
----
📚 Documentation preview 📚: https://anemoi-inference--554.org.readthedocs.build/en/554/

<!-- readthedocs-preview anemoi-inference end -->