### PR TITLE
feat(inputs): add `forcings_from_forecast` option

### DIFF
--- a/src/anemoi/inference/inputs/cds.py
+++ b/src/anemoi/inference/inputs/cds.py
@@ -245,7 +245,7 @@ class CDSInput(GribInput):
             The loaded forcings state.
         """
         if self.forcings_from_forecast:
-            LOG.debug("CDSInput: Loading forcings from forecast for dates: %s", dates)
+            LOG.debug("%s: Loading forcings from forecast for dates: %s", self.__class__.__name__, dates)
             date, steps = convert_dates_to_base_and_step(dates)
             retrieved_state = self.retrieve(self.variables, [date], step=steps)
         else:

--- a/src/anemoi/inference/inputs/cds.py
+++ b/src/anemoi/inference/inputs/cds.py
@@ -24,6 +24,7 @@ from anemoi.inference.types import State
 from . import input_registry
 from .grib import GribInput
 from .mars import postproc
+from .utils import convert_dates_to_base_and_step
 
 LOG = logging.getLogger(__name__)
 
@@ -120,6 +121,7 @@ class CDSInput(GribInput):
         dataset: str | dict[str, Any],
         namer: Any | None = None,
         purpose: str | None = None,
+        forcings_from_forecast: bool = False,
         **kwargs: Any,
     ) -> None:
         """Initialize the CDSInput.
@@ -138,11 +140,21 @@ class CDSInput(GribInput):
             The dataset to use.
         namer : Optional[Any]
             Optional namer for the input.
+        purpose : Optional[str]
+            The purpose of the input (e.g., 'forcings', 'constants'). Used for debugging and logging.
+        forcings_from_forecast : bool
+            Whether to get forcings from a forecast, i.e. selecting from step, rather than basedate.
         **kwargs : Any
             Additional keyword arguments.
         """
         super().__init__(
-            context, metadata, variables=variables, pre_processors=pre_processors, namer=namer, purpose=purpose
+            context,
+            metadata,
+            variables=variables,
+            pre_processors=pre_processors,
+            namer=namer,
+            purpose=purpose,
+            forcings_from_forecast=forcings_from_forecast,
         )
 
         self.dataset = dataset
@@ -177,7 +189,7 @@ class CDSInput(GribInput):
             **kwargs,
         )
 
-    def retrieve(self, variables: list[str], dates: list[Date]) -> Any:
+    def retrieve(self, variables: list[str], dates: list[Date], **kwargs) -> Any:
         """Retrieve data for the given variables and dates.
 
         Parameters
@@ -186,6 +198,8 @@ class CDSInput(GribInput):
             List of variables to retrieve.
         dates : List[Date]
             List of dates for which to retrieve data.
+        **kwargs : Any
+            Additional keyword arguments to pass to the retrieval function.
 
         Returns
         -------
@@ -203,8 +217,16 @@ class CDSInput(GribInput):
         if not requests:
             raise ValueError(f"No requests for {variables} ({dates})")
 
+        retrieval_kwargs = self.kwargs.copy()
+        retrieval_kwargs.update(kwargs)
+
         return retrieve(
-            requests, self.metadata.grid, self.metadata.area, dataset=self.dataset, expver="0001", **self.kwargs
+            requests,
+            self.metadata.grid,
+            self.metadata.area,
+            dataset=self.dataset,
+            expver="0001",
+            **retrieval_kwargs,
         )
 
     def load_forcings_state(self, *, dates: list[Date], current_state: State) -> State:
@@ -222,8 +244,15 @@ class CDSInput(GribInput):
         Any
             The loaded forcings state.
         """
+        if self.forcings_from_forecast:
+            LOG.debug("CDSInput: Loading forcings from forecast for dates: %s", dates)
+            date, steps = convert_dates_to_base_and_step(dates)
+            retrieved_state = self.retrieve(self.variables, [date], step=steps)
+        else:
+            retrieved_state = self.retrieve(self.variables, dates)
+
         return self._load_forcings_state(
-            self.retrieve(self.variables, dates),
+            retrieved_state,
             dates=dates,
             current_state=current_state,
         )

--- a/src/anemoi/inference/inputs/cds.py
+++ b/src/anemoi/inference/inputs/cds.py
@@ -24,7 +24,6 @@ from anemoi.inference.types import State
 from . import input_registry
 from .grib import GribInput
 from .mars import postproc
-from .utils import convert_dates_to_base_and_step
 
 LOG = logging.getLogger(__name__)
 
@@ -121,7 +120,6 @@ class CDSInput(GribInput):
         dataset: str | dict[str, Any],
         namer: Any | None = None,
         purpose: str | None = None,
-        forcings_from_forecast: bool = False,
         **kwargs: Any,
     ) -> None:
         """Initialize the CDSInput.
@@ -142,8 +140,6 @@ class CDSInput(GribInput):
             Optional namer for the input.
         purpose : Optional[str]
             The purpose of the input (e.g., 'forcings', 'constants'). Used for debugging and logging.
-        forcings_from_forecast : bool
-            Whether to get forcings from a forecast, i.e. selecting from step, rather than basedate.
         **kwargs : Any
             Additional keyword arguments.
         """
@@ -154,7 +150,6 @@ class CDSInput(GribInput):
             pre_processors=pre_processors,
             namer=namer,
             purpose=purpose,
-            forcings_from_forecast=forcings_from_forecast,
         )
 
         self.dataset = dataset
@@ -189,7 +184,7 @@ class CDSInput(GribInput):
             **kwargs,
         )
 
-    def retrieve(self, variables: list[str], dates: list[Date], **kwargs) -> Any:
+    def retrieve(self, variables: list[str], dates: list[Date]) -> Any:
         """Retrieve data for the given variables and dates.
 
         Parameters
@@ -198,8 +193,6 @@ class CDSInput(GribInput):
             List of variables to retrieve.
         dates : List[Date]
             List of dates for which to retrieve data.
-        **kwargs : Any
-            Additional keyword arguments to pass to the retrieval function.
 
         Returns
         -------
@@ -217,16 +210,13 @@ class CDSInput(GribInput):
         if not requests:
             raise ValueError(f"No requests for {variables} ({dates})")
 
-        retrieval_kwargs = self.kwargs.copy()
-        retrieval_kwargs.update(kwargs)
-
         return retrieve(
             requests,
             self.metadata.grid,
             self.metadata.area,
             dataset=self.dataset,
             expver="0001",
-            **retrieval_kwargs,
+            **self.kwargs.copy(),
         )
 
     def load_forcings_state(self, *, dates: list[Date], current_state: State) -> State:
@@ -244,15 +234,8 @@ class CDSInput(GribInput):
         Any
             The loaded forcings state.
         """
-        if self.forcings_from_forecast:
-            LOG.debug("CDSInput: Loading forcings from forecast for dates: %s", dates)
-            date, steps = convert_dates_to_base_and_step(dates)
-            retrieved_state = self.retrieve(self.variables, [date], step=steps)
-        else:
-            retrieved_state = self.retrieve(self.variables, dates)
-
         return self._load_forcings_state(
-            retrieved_state,
+            self.retrieve(self.variables, dates),
             dates=dates,
             current_state=current_state,
         )

--- a/src/anemoi/inference/inputs/ekd.py
+++ b/src/anemoi/inference/inputs/ekd.py
@@ -136,6 +136,7 @@ class EkdInput(Input):
         metadata: Metadata,
         *,
         namer: Any | None = None,
+        forcings_from_forecast: bool = False,
         **kwargs,
     ) -> None:
         """Initialize the EkdInput.
@@ -148,8 +149,11 @@ class EkdInput(Input):
             Metadata corresponding to the dataset this input is handling.
         namer : Optional[Union[Callable[[Any, Dict[str, Any]], str], Dict[str, Any]]]
             Optional namer for the input.
+        forcings_from_forecast: bool
+            Whether to get forcings from a forecast, i.e. selecting from step, rather than basedate.
         """
         super().__init__(context, metadata, **kwargs)
+        self.forcings_from_forecast = forcings_from_forecast
 
         if isinstance(namer, dict):
             # TODO: a factory for namers
@@ -245,6 +249,7 @@ class EkdInput(Input):
         dtype: DTypeLike = np.float32,
         flatten: bool = True,
         ref_date_index: int = -1,
+        select_reference_date: bool = False,
         **kwargs,
     ) -> State:
         """Create a state from an ekd.FieldList.
@@ -272,6 +277,9 @@ class EkdInput(Input):
             Whether to flatten the data.
         ref_date_index: int = -1
             If 0 takes the first date, if -1 takes the last date in sequence.
+        select_reference_date: bool, optional
+            Also include the reference date when selecting data from the FieldList.
+            If False (default), only the valid date is considered.
         **kwargs : Any
             Additional arguments for selecting the variable.
 
@@ -320,7 +328,9 @@ class EkdInput(Input):
         dates = sorted([to_datetime(d) for d in dates])
         date_to_index = {d.isoformat(): i for i, d in enumerate(dates)}
 
-        fields = self._filter_and_sort(fields, dates=dates, title="Create input state", **kwargs)
+        fields = self._filter_and_sort(
+            fields, dates=dates, title="Create input state", select_reference_date=select_reference_date, **kwargs
+        )
 
         check = defaultdict(set)
         state_variables = {}
@@ -469,6 +479,7 @@ class EkdInput(Input):
             longitudes=current_state.get("longitudes", None),
             dtype=np.float32,
             flatten=True,
+            select_reference_date=self.forcings_from_forecast,
         )
 
     def set_private_attributes(self, state: State, fields: ekd.FieldList) -> None:  # type: ignore

--- a/src/anemoi/inference/inputs/fdb.py
+++ b/src/anemoi/inference/inputs/fdb.py
@@ -22,6 +22,7 @@ from anemoi.inference.types import State
 
 from . import input_registry
 from .grib import GribInput
+from .utils import convert_dates_to_base_and_step
 
 LOG = logging.getLogger(__name__)
 
@@ -43,6 +44,7 @@ class FDBInput(GribInput):
         pre_processors: list[ProcessorConfig] | None = None,
         namer: Any | None = None,
         purpose: str | None = None,
+        forcings_from_forecast: bool = False,
         **kwargs: Any,
     ) -> None:
         """Initialise the FDB input.
@@ -75,6 +77,7 @@ class FDBInput(GribInput):
             pre_processors=pre_processors,
             purpose=purpose,
             namer=namer,
+            forcings_from_forecast=forcings_from_forecast,
         )
         self.kwargs = kwargs
         self.configs = {"config": fdb_config, "userconfig": fdb_userconfig}
@@ -89,17 +92,25 @@ class FDBInput(GribInput):
         return res
 
     def load_forcings_state(self, *, dates: list[Date], current_state: State) -> State:
-        ds = self.retrieve(variables=self.variables, dates=dates)
+        if self.forcings_from_forecast:
+            LOG.debug("FDBInput: Loading forcings from forecast for dates: %s", dates)
+            date, steps = convert_dates_to_base_and_step(dates)
+            ds = self.retrieve(self.variables, [date], step=steps)
+        else:
+            ds = self.retrieve(variables=self.variables, dates=dates)
         return self._load_forcings_state(ds, dates=dates, current_state=current_state)
 
-    def retrieve(self, variables: list[str], dates: list[Date]) -> Any:
+    def retrieve(self, variables: list[str], dates: list[Date], **kwargs) -> Any:
         requests = self.metadata.mars_requests(
             variables=variables,
             dates=dates,
             use_grib_paramid=self.context.use_grib_paramid,
             patch_request=self.patch_data_request,
         )
-        requests = [self.kwargs | r for r in requests]
+        retrieval_kwargs = self.kwargs.copy()
+        retrieval_kwargs.update(kwargs)
+
+        requests = [retrieval_kwargs | r for r in requests]
         # NOTE: this is a temporary workaround for #191
         for request in requests:
             request["param"] = [self.param_id_map.get(p, p) for p in request["param"]]

--- a/src/anemoi/inference/inputs/fdb.py
+++ b/src/anemoi/inference/inputs/fdb.py
@@ -94,8 +94,9 @@ class FDBInput(GribInput):
     def load_forcings_state(self, *, dates: list[Date], current_state: State) -> State:
         if self.forcings_from_forecast:
             LOG.debug("FDBInput: Loading forcings from forecast for dates: %s", dates)
-            date, steps = convert_dates_to_base_and_step(dates)
-            ds = self.retrieve(self.variables, [date], step=steps)
+            base_date = current_state["date"] - current_state["step"]
+            date, steps = convert_dates_to_base_and_step(dates, base_date=base_date)
+            ds = self.retrieve(self.variables, [date], step=steps, type="fc")
         else:
             ds = self.retrieve(variables=self.variables, dates=dates)
         return self._load_forcings_state(ds, dates=dates, current_state=current_state)

--- a/src/anemoi/inference/inputs/fdb.py
+++ b/src/anemoi/inference/inputs/fdb.py
@@ -93,7 +93,7 @@ class FDBInput(GribInput):
 
     def load_forcings_state(self, *, dates: list[Date], current_state: State) -> State:
         if self.forcings_from_forecast:
-            LOG.debug("FDBInput: Loading forcings from forecast for dates: %s", dates)
+            LOG.debug("%s: Loading forcings from forecast for dates: %s", self.__class__.__name__, dates)
             date, steps = convert_dates_to_base_and_step(dates)
             ds = self.retrieve(self.variables, [date], step=steps)
         else:

--- a/src/anemoi/inference/inputs/mars.py
+++ b/src/anemoi/inference/inputs/mars.py
@@ -339,7 +339,7 @@ class MarsInput(GribInput):
             The loaded forcings state.
         """
         if self.forcings_from_forecast:
-            LOG.debug("MarsInput: Loading forcings from forecast for dates: %s", dates)
+            LOG.debug("%s: Loading forcings from forecast for dates: %s", self.__class__.__name__, dates)
             date, steps = convert_dates_to_base_and_step(dates)
             retrieved_state = self.retrieve(self.variables, [date], step=steps)
         else:

--- a/src/anemoi/inference/inputs/mars.py
+++ b/src/anemoi/inference/inputs/mars.py
@@ -22,6 +22,7 @@ from anemoi.inference.types import State
 
 from . import input_registry
 from .grib import GribInput
+from .utils import convert_dates_to_base_and_step
 
 LOG = logging.getLogger(__name__)
 
@@ -282,15 +283,17 @@ class MarsInput(GribInput):
             **kwargs,
         )
 
-    def retrieve(self, variables: list[str], dates: list[Date]) -> Any:
+    def retrieve(self, variables: list[str], dates: list[Date], **kwargs) -> Any:
         """Retrieve data for the given variables and dates.
 
         Parameters
         ----------
         variables : List[str]
             The list of variables to retrieve.
-        dates : List[Any]
+        dates : List[Date]
             The list of dates for which to retrieve the data.
+        **kwargs : Any
+            Additional keyword arguments to pass to the retrieval function.
 
         Returns
         -------
@@ -307,16 +310,17 @@ class MarsInput(GribInput):
         if not requests:
             raise ValueError(f"No requests for {variables} ({dates})")
 
-        kwargs = self.kwargs.copy()
-        kwargs.setdefault("expver", "0001")
-        kwargs.setdefault("grid", self.metadata.grid)
-        kwargs.setdefault("area", self.metadata.area)
+        retrieval_kwargs = self.kwargs.copy()
+        retrieval_kwargs.update(kwargs)
+        retrieval_kwargs.setdefault("expver", "0001")
+        retrieval_kwargs.setdefault("grid", self.metadata.grid)
+        retrieval_kwargs.setdefault("area", self.metadata.area)
 
         return retrieve(
             requests,
             patch=self.patch,
             log=self.log,
-            **kwargs,
+            **retrieval_kwargs,
         )
 
     def load_forcings_state(self, *, dates: list[Date], current_state: State) -> State:
@@ -334,8 +338,15 @@ class MarsInput(GribInput):
         Any
             The loaded forcings state.
         """
+        if self.forcings_from_forecast:
+            LOG.debug("MarsInput: Loading forcings from forecast for dates: %s", dates)
+            date, steps = convert_dates_to_base_and_step(dates)
+            retrieved_state = self.retrieve(self.variables, [date], step=steps)
+        else:
+            retrieved_state = self.retrieve(self.variables, dates)
+
         return self._load_forcings_state(
-            self.retrieve(self.variables, dates),
+            retrieved_state,
             dates=dates,
             current_state=current_state,
         )

--- a/src/anemoi/inference/inputs/mars.py
+++ b/src/anemoi/inference/inputs/mars.py
@@ -213,6 +213,7 @@ class MarsInput(GribInput):
         pre_processors: list[ProcessorConfig] | None = None,
         namer: Any | None = None,
         purpose: str | None = None,
+        forcings_from_forecast: bool = False,
         **kwargs: Any,
     ) -> None:
         """Initialize the MarsInput.
@@ -231,6 +232,12 @@ class MarsInput(GribInput):
             Optional list of patches for the input.
         log : bool
             Whether to log the requests to MARS, by default True.
+        pre_processors : list of ProcessorConfig or None, optional
+            List of pre-processors to apply to the input. If None, no pre-processing is performed.
+        purpose : str or None, optional
+            The purpose of the input (e.g., 'forcings', 'constants'). Used for debugging and logging.
+        forcings_from_forecast : bool
+            Whether to get forcings from a forecast, i.e. selecting from step, rather than basedate.
         **kwargs : Any
             Additional keyword to pass to the request to MARS.
         """
@@ -241,6 +248,7 @@ class MarsInput(GribInput):
             pre_processors=pre_processors,
             purpose=purpose,
             namer=namer,
+            forcings_from_forecast=forcings_from_forecast,
         )
 
         self.kwargs = kwargs
@@ -338,10 +346,12 @@ class MarsInput(GribInput):
         Any
             The loaded forcings state.
         """
+
         if self.forcings_from_forecast:
             LOG.debug("MarsInput: Loading forcings from forecast for dates: %s", dates)
-            date, steps = convert_dates_to_base_and_step(dates)
-            retrieved_state = self.retrieve(self.variables, [date], step=steps)
+            base_date = current_state["date"] - current_state["step"]
+            date, steps = convert_dates_to_base_and_step(dates, base_date=base_date)
+            retrieved_state = self.retrieve(self.variables, [date], step=steps, type="fc")
         else:
             retrieved_state = self.retrieve(self.variables, dates)
 

--- a/src/anemoi/inference/inputs/utils.py
+++ b/src/anemoi/inference/inputs/utils.py
@@ -12,13 +12,15 @@ from earthkit.data.utils.dates import to_datetime
 from anemoi.inference.types import Date
 
 
-def convert_dates_to_base_and_step(dates: list[Date]) -> tuple[Date, list[int]]:
+def convert_dates_to_base_and_step(dates: list[Date], base_date: Date | None = None) -> tuple[Date, list[int]]:
     """Convert a list of dates to base and step.
 
     Parameters
     ----------
     dates : list[Date]
         List of dates to convert.
+    base_date : Date or None
+        The base date to use. If None, the earliest date in the list is used.
 
     Returns
     -------
@@ -29,7 +31,7 @@ def convert_dates_to_base_and_step(dates: list[Date]) -> tuple[Date, list[int]]:
         raise ValueError("The list of dates is empty.")
     datetimes = [to_datetime(date) for date in dates]
 
-    base_date = min(datetimes)
-    steps = [(dt - to_datetime(base_date)).total_seconds() // 3600 for dt in datetimes]
+    base_date = to_datetime(base_date) if base_date else min(datetimes)
+    steps = [int((dt - to_datetime(base_date)).total_seconds() // 3600) for dt in datetimes]
 
     return base_date, steps

--- a/src/anemoi/inference/inputs/utils.py
+++ b/src/anemoi/inference/inputs/utils.py
@@ -1,0 +1,35 @@
+# (C) Copyright 2026 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+from earthkit.data.utils.dates import to_datetime
+
+from anemoi.inference.types import Date
+
+
+def convert_dates_to_base_and_step(dates: list[Date]) -> tuple[Date, list[int]]:
+    """Convert a list of dates to base and step.
+
+    Parameters
+    ----------
+    dates : list[Date]
+        List of dates to convert.
+
+    Returns
+    -------
+    tuple[Date, list[int]]
+        The base date and the list of steps in hours.
+    """
+    if not dates:
+        raise ValueError("The list of dates is empty.")
+    datetimes = [to_datetime(date) for date in dates]
+
+    base_date = min(datetimes)
+    steps = [(dt - to_datetime(base_date)).total_seconds() // 3600 for dt in datetimes]
+
+    return base_date, steps


### PR DESCRIPTION
## Description
Allow for forecast states to be used as forcings, by retrieving on step and base date instead of at step 0 for all valid dates.
Useful for running inference in a semi coupled way

```yaml
input:
	mars:
 		forcings_from_forecast: true
```

## TODO

- [x] Consider if temporal downscaler selection needs to be reworked 
	- A different probkem
- [x] Identify if other inputs are to be updated
	- All seem good
- [x] Unify dataset kwarg?
	- Slightly different, as the ds is a different shape

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
