### PR TITLE
fix(parallel output): Remove unpicklable key and add integration test

### DIFF
--- a/src/anemoi/inference/outputs/parallel.py
+++ b/src/anemoi/inference/outputs/parallel.py
@@ -137,7 +137,7 @@ def _sanitise_state(state: State, grib_templates_bytes: dict[str, bytes] | None 
     same templates dict N times when there are N writers.
     """
 
-    unpicklable_keys = ["_input"]
+    unpicklable_keys = ["_input", "_variables"]
 
     state = state.copy()
 

--- a/tests/integration/single-o48-1.1/config.yaml
+++ b/tests/integration/single-o48-1.1/config.yaml
@@ -27,6 +27,26 @@
             class: ai
             type: fc
 
+- name: grib-in-grib-parallel-out
+  input: input.grib
+  output: output
+  checks:
+    - check_files_in_directory:
+        expected_files: 2
+    - check_file_exist:
+        file: ${output:}/output_w0.grib
+    - check_file_exist:
+        file: ${output:}/output_w1.grib
+  inference_config:
+    write_initial_state: true
+    checkpoint: ${checkpoint:}
+    input:
+      grib: ${input:}
+    output:
+      parallel:
+        num_writers: 2
+        grib: ${output:}/output.grib
+
 - name: grib-in-grib-out-limit-vars
   input: input.grib
   output: output.grib

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -230,6 +230,9 @@ def test_integration(test_setup: Setup, tmp_path: Path) -> None:
             Variable.from_dict(var, {"param": var}) for var in expected_variables_config
         ] or checkpoint_output_variables[dataset_name]
 
+        if not isinstance(file, Path):
+            file = Path(file)
+
         testing_registry.create(
             check,
             file=file,


### PR DESCRIPTION
## Description
#513 added a new private `_variables` entry to the state that cannot be pickled, making the output crash. It's only used by the runner, so we can safely remove it.

Also add an integration test for parallel grib out so we don't break it again.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
