### PR TITLE
fix(retrieve): Ensure we flush/close file we write requests to

### DIFF
--- a/src/anemoi/inference/commands/retrieve.py
+++ b/src/anemoi/inference/commands/retrieve.py
@@ -300,15 +300,16 @@ class RetrieveCmd(Command):
             requests[0]["target"] = args.target
 
         if args.output and args.output != "-":
-            f = open(args.output, "w")
+            with open(args.output, "w") as f:
+                self._write_requests(requests, f, args)
         else:
-            f = sys.stdout
+            self._write_requests(requests, sys.stdout, args)
 
+    def _write_requests(self, requests, f, args):
         if args.mars:
             # Write requests in MARS format
-            for i, request in enumerate(requests):
+            for request in requests:
                 print_request(args.verb, request, file=f)
-
         else:
             json.dump(requests, f, indent=4)
 


### PR DESCRIPTION
## Description

Ensures the file is closed when we write out MARS requests - #563 

## What problem does this change solve?

Bugfix

## What issue or task does this change relate to?

#563 

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
