### PR TITLE
perf(inputs): keep inputs grid-sharded

### DIFF
--- a/src/anemoi/inference/runner.py
+++ b/src/anemoi/inference/runner.py
@@ -274,6 +274,20 @@ class Runner(Context):
                             state[name]["fields"][field_name] = field.cpu().numpy()
             yield state
 
+    def prepare_forecast_input_tensors(
+        self, input_tensors_torch: dict[str, "torch.Tensor"]
+    ) -> dict[str, "torch.Tensor"]:
+        """Prepare device tensors before entering the autoregressive loop."""
+        return input_tensors_torch
+
+    def prepare_forecast_output_state(self, state: dict[str, State]) -> dict[str, State]:
+        """Prepare a forecast state for yielding without changing rollout state."""
+        return state
+
+    def grid_shard_slice(self, dataset: str) -> slice:
+        """Return the local interval along the grid dimension."""
+        return slice(None)
+
     @cached_property
     def autocast(self) -> Union["torch.dtype", str]:
         """The autocast precision."""
@@ -443,6 +457,7 @@ class Runner(Context):
                 dataset: torch.from_numpy(np.swapaxes(input_tensor_numpy, -2, -1)[np.newaxis, ...]).to(self.device)
                 for dataset, input_tensor_numpy in input_tensors_numpy.items()
             }
+            input_tensors_torch = self.prepare_forecast_input_tensors(input_tensors_torch)
 
             lead_time = to_timedelta(lead_time)
 
@@ -547,7 +562,7 @@ class Runner(Context):
 
                     # we only need to check the first dataset's step as they should all be the same
                     if next(iter(new_states.values()))["step"] <= lead_time:
-                        yield new_states
+                        yield self.prepare_forecast_output_state(new_states)
 
                 # No need to prepare next input tensor if we are at the last autoregressive step
                 if is_last_step:
@@ -696,13 +711,16 @@ class Runner(Context):
 
         for states in self.run(input_states=input_states, lead_time=lead_time):
             for dataset, state in states.items():
-                # Apply top-level post-processors
-                for processor in self.post_processors[dataset]:
-                    state = processor.process(state)
-                self.outputs[dataset].write_state(state)
+                self.write_output_state(dataset, state)
 
         for output in self.outputs.values():
             output.close()
+
+    def write_output_state(self, dataset: str, state: State) -> None:
+        """Apply top-level post-processors and write one forecast state."""
+        for processor in self.post_processors[dataset]:
+            state = processor.process(state)
+        self.outputs[dataset].write_state(state)
 
     #########################################################################################################
     def create_output(self, dataset_name: str, metadata: Metadata) -> Output:

--- a/src/anemoi/inference/runners/parallel.py
+++ b/src/anemoi/inference/runners/parallel.py
@@ -30,6 +30,28 @@ from . import runner_registry
 LOG = logging.getLogger(__name__)
 
 
+def _gather_grid_tensor_to_master(
+    tensor: "torch.Tensor",
+    shard_sizes: list[int],
+    process_group: "torch.distributed.ProcessGroup",
+    is_master: bool,
+) -> "torch.Tensor | None":
+    """Gather uneven grid shards on rank 0 without materialising the full tensor elsewhere."""
+    max_shard_size = max(shard_sizes)
+    padded_shape = list(tensor.shape)
+    padded_shape[0] = max_shard_size
+    padded = torch.empty(padded_shape, dtype=tensor.dtype, device=tensor.device)
+    padded[: tensor.shape[0]].copy_(tensor)
+
+    gathered = [torch.empty_like(padded) for _ in shard_sizes] if is_master else None
+    torch.distributed.gather(padded, gather_list=gathered, dst=0, group=process_group)
+
+    if not is_master:
+        return None
+
+    return torch.cat([shard[:size] for shard, size in zip(gathered, shard_sizes)], dim=0)
+
+
 def create_parallel_runner(config: Configuration, client_factory: ComputeClientFactory) -> None:
     """Creates and runs a parallel runner.
 
@@ -136,6 +158,7 @@ class ParallelRunnerMixin(Runner):
 
         self.compute_client = compute_client
         self.is_master = compute_client.is_master
+        self.grid_shard_sizes: dict[str, list[int]] = {}
 
         super().__init__(config, **kwargs)
 
@@ -179,6 +202,103 @@ class ParallelRunnerMixin(Runner):
 
         torch.manual_seed(seed)
 
+    def prepare_forecast_input_tensors(
+        self, input_tensors_torch: dict[str, "torch.Tensor"]
+    ) -> dict[str, "torch.Tensor"]:
+        """Shard full-grid input tensors once before autoregressive inference."""
+        process_group = self.compute_client.process_group
+        if process_group is None:
+            return input_tensors_torch
+
+        from anemoi.models.distributed.graph import shard_tensor
+        from anemoi.models.distributed.shapes import get_shard_sizes
+
+        for dataset, tensor in input_tensors_torch.items():
+            shard_sizes = get_shard_sizes(tensor, -2, model_comm_group=process_group)
+            assert shard_sizes is not None
+            self.grid_shard_sizes[dataset] = shard_sizes
+            input_tensors_torch[dataset] = shard_tensor(tensor, -2, shard_sizes, process_group)
+
+        return input_tensors_torch
+
+    def grid_shard_slice(self, dataset: str) -> slice:
+        """Return this rank's interval in the full grid."""
+        shard_sizes = self.grid_shard_sizes.get(dataset)
+        if shard_sizes is None:
+            return slice(None)
+
+        process_group = self.compute_client.process_group
+        assert process_group is not None
+        rank = process_group.rank()
+        start = sum(shard_sizes[:rank])
+        return slice(start, start + shard_sizes[rank])
+
+    def prepare_forecast_output_state(self, state: dict[str, Any]) -> dict[str, Any]:
+        """Gather all forecast fields together on rank 0 while keeping rollout state sharded."""
+        process_group = self.compute_client.process_group
+        if process_group is None:
+            return state
+
+        result = {}
+        for dataset, dataset_state in state.items():
+            output_state = dataset_state.copy()
+            output_state["fields"] = {}
+            shard_sizes = self.grid_shard_sizes[dataset]
+            fields = dataset_state["fields"]
+            if not fields:
+                result[dataset] = output_state
+                continue
+
+            field_names = list(fields)
+            field_tensors = list(fields.values())
+            grid_sizes = {field.shape[0] for field in field_tensors}
+            full_grid_size = sum(shard_sizes)
+            rank = process_group.rank()
+
+            if grid_sizes == {full_grid_size}:
+                if self.is_master:
+                    output_state["fields"] = fields.copy()
+                result[dataset] = output_state
+                continue
+
+            if grid_sizes != {shard_sizes[rank]}:
+                raise ValueError(
+                    f"[{dataset}] fields have grid sizes {sorted(grid_sizes)}, expected "
+                    f"local shard size {shard_sizes[rank]} or full grid size {full_grid_size}"
+                )
+
+            if any(field.ndim != 1 for field in field_tensors):
+                shapes = {name: tuple(field.shape) for name, field in fields.items()}
+                raise ValueError(f"[{dataset}] fields must be one-dimensional grid tensors, got {shapes}")
+
+            dtypes = {field.dtype for field in field_tensors}
+            devices = {field.device for field in field_tensors}
+            if len(dtypes) != 1 or len(devices) != 1:
+                raise ValueError(
+                    f"[{dataset}] fields must share one dtype and device for a packed gather, "
+                    f"got dtypes={dtypes}, devices={devices}"
+                )
+
+            packed_fields = torch.stack(field_tensors, dim=1)
+            LOG.debug(
+                "Rank %d gathering %d [%s] fields with packed local shape %s",
+                rank,
+                len(field_names),
+                dataset,
+                tuple(packed_fields.shape),
+            )
+            gathered = _gather_grid_tensor_to_master(packed_fields, shard_sizes, process_group, self.is_master)
+            if self.is_master:
+                output_state["fields"] = {name: gathered[:, index] for index, name in enumerate(field_names)}
+            result[dataset] = output_state
+
+        return result
+
+    def write_output_state(self, dataset: str, state: dict[str, Any]) -> None:
+        """Only rank 0 owns full-grid forecast output."""
+        if self.is_master:
+            super().write_output_state(dataset, state)
+
     def predict_step(self, model: Any, input_tensor_torch: "torch.Tensor", **kwargs: Any) -> "torch.Tensor":
         """Performs a prediction step.
 
@@ -203,8 +323,14 @@ class ParallelRunnerMixin(Runner):
             return super().predict_step(model, input_tensor_torch, **kwargs)
         else:
             try:
+                if self.grid_shard_sizes:
+                    kwargs["grid_shard_sizes"] = self.grid_shard_sizes
+                    kwargs["gather_out"] = False
                 return super().predict_step(
-                    model, input_tensor_torch, model_comm_group=self.compute_client.process_group, **kwargs
+                    model,
+                    input_tensor_torch,
+                    model_comm_group=self.compute_client.process_group,
+                    **kwargs,
                 )
             except TypeError as err:
                 LOG.error(

--- a/src/anemoi/inference/runners/parallel.py
+++ b/src/anemoi/inference/runners/parallel.py
@@ -40,7 +40,7 @@ def _gather_grid_tensor_to_master(
     max_shard_size = max(shard_sizes)
     padded_shape = list(tensor.shape)
     padded_shape[0] = max_shard_size
-    padded = torch.empty(padded_shape, dtype=tensor.dtype, device=tensor.device)
+    padded = torch.zeros(padded_shape, dtype=tensor.dtype, device=tensor.device)
     padded[: tensor.shape[0]].copy_(tensor)
 
     gathered = [torch.empty_like(padded) for _ in shard_sizes] if is_master else None

--- a/src/anemoi/inference/tensors.py
+++ b/src/anemoi/inference/tensors.py
@@ -459,6 +459,7 @@ class TensorHandler:
                 forcings[np.newaxis, :, np.newaxis, ...], -2, -1
             )  # shape: (1, dates, 1, values, variables)
 
+            forcings = forcings[..., self.context.grid_shard_slice(self.dataset_name), :]
             forcings = torch.from_numpy(forcings).to(self.context.device)  # Copy to device
 
             for i in range(min(self.metadata.multi_step_output, self.metadata.multi_step_input)):
@@ -496,10 +497,18 @@ class TensorHandler:
             forcings = np.swapaxes(
                 forcings[np.newaxis, :, np.newaxis, ...], -2, -1
             )  # shape: (1, dates, 1, values, variables)
+
+            grid_slice = self.context.grid_shard_slice(self.dataset_name)
+            local_spatial_mask = source.spatial_mask[grid_slice]
+            grid_start = 0 if grid_slice.start is None else grid_slice.start
+            # forcings contain only boundary points: translate the full-grid shard into this compressed axis
+            boundary_offset = np.count_nonzero(source.spatial_mask[:grid_start])
+            local_boundary_count = np.count_nonzero(local_spatial_mask)
+            forcings = forcings[..., boundary_offset : boundary_offset + local_boundary_count, :]
             forcings = torch.from_numpy(forcings).to(self.context.device)  # Copy to device
 
             for i in range(min(self.metadata.multi_step_output, self.metadata.multi_step_input)):
-                total_mask = np.ix_([0], [-(i + 1)], source.spatial_mask, source.variables_mask)
+                total_mask = np.ix_([0], [-(i + 1)], local_spatial_mask, source.variables_mask)
                 input_tensor_torch[total_mask] = forcings[
                     :, -(i + 1), ...
                 ]  # Copy forcings to corresponding 'multi_step_input' row

--- a/tests/unit/test_forecast.py
+++ b/tests/unit/test_forecast.py
@@ -77,6 +77,7 @@ def forecast_runner_factory():
         runner = Runner.__new__(Runner)
 
         metadata = SimpleNamespace(
+            dataset_name="data",
             timestep=timedelta(hours=1),
             multi_step_input=multi_step_input,
             multi_step_output=multi_step_output,


### PR DESCRIPTION
## Description
Keep input and autoregressive rollout tensors sharded across model ranks, gathering forecast fields only to rank 0 when producing output.

Companion anemoi-models change: https://github.com/ecmwf/anemoi-core/pull/1345

## What problem does this change solve?
For high-resolution tasks like 4km downscaling, storing full non-grid-sharded inputs can take up a majority of GPU memory. This PR makes the memory usage for parallel inference scalable i.e. n gpus/model -> 1/n x memory requirements for storing input tensors.

> [!WARNING]
> Requires this anemoi-core change for compatibility: https://github.com/ecmwf/anemoi-core/pull/1345

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
