### PR TITLE
refactor(inputs/cutout): fix input state creation by removing coordinate loading

### DIFF
--- a/src/anemoi/inference/inputs/cutout.py
+++ b/src/anemoi/inference/inputs/cutout.py
@@ -182,32 +182,10 @@ class Cutout(Input):
         combined_state = {}
 
         for i, source in enumerate(self.sources.keys()):
-
             source_mask = self.masks[source]
-
-            try:
-                latitudes, longitudes = self.sources[source]._fieldlist[0].grid_points()
-            except Exception as e:
-                LOG.warning("Failed to get coordinates from source %s: %s", source, e)
-                LOG.warning(
-                    "Loading coordinates from supporting arrays  %s and %s",
-                    f"source{i}/latitudes",
-                    f"source{i}/longitudes",
-                )
-                latitudes = self.metadata.load_supporting_array(f"source{i}/latitudes")
-                longitudes = self.metadata.load_supporting_array(f"source{i}/longitudes")
-
-                # this fallback for getting coordinates is index-based and therefore sensitive to
-                # the order of the sources in the configuration
-                if isinstance(source_mask, np.ndarray):
-                    assert source_mask.shape == latitudes.shape, (
-                        "Expected source mask shape to match coordinates shape. "
-                        f"Got mask of shape {source_mask.shape} and latitudes of shape {latitudes.shape}. "
-                        "Check that the cutout sources are in the correct order."
-                    )
-
+            
             source_state = self.sources[source].create_input_state(
-                date=date, latitudes=latitudes, longitudes=longitudes, **kwargs
+                date=date, **kwargs
             )
 
             # Create the mask front padded with zeros

--- a/src/anemoi/inference/inputs/cutout.py
+++ b/src/anemoi/inference/inputs/cutout.py
@@ -183,10 +183,8 @@ class Cutout(Input):
 
         for i, source in enumerate(self.sources.keys()):
             source_mask = self.masks[source]
-            
-            source_state = self.sources[source].create_input_state(
-                date=date, **kwargs
-            )
+
+            source_state = self.sources[source].create_input_state(date=date, **kwargs)
 
             # Create the mask front padded with zeros
             # to match the length of the combined state


### PR DESCRIPTION
## Description
Removed fallback mechanism for loading coordinates from sources and adjusted input state creation.


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
