### PR TITLE
fix(metadata): correctly resolve checkpoint variable names in default_namer

### DIFF
--- a/src/anemoi/inference/metadata.py
+++ b/src/anemoi/inference/metadata.py
@@ -602,10 +602,6 @@ class Metadata(LegacyMixin):
         assert len(args) == 0, args
         assert len(kwargs) == 0, kwargs
 
-        # Reverse lookup from the checkpoint's own (param, levelist) to variable
-        # name, using each variable's mars metadata. This lets us recover names
-        # like `z_100` even when the input's GRIB `param` doesn't match the
-        # checkpoint's variable name (e.g. `FI` vs `z`).
         param_levelist_to_name = {
             (variable.param, variable.level): name for name, variable in self.typed_variables.items()
         }

--- a/src/anemoi/inference/metadata.py
+++ b/src/anemoi/inference/metadata.py
@@ -602,9 +602,15 @@ class Metadata(LegacyMixin):
         assert len(args) == 0, args
         assert len(kwargs) == 0, kwargs
 
+        # Reverse lookup from the checkpoint's own (param, levelist) to variable
+        # name, using each variable's mars metadata. This lets us recover names
+        # like `z_100` even when the input's GRIB `param` doesn't match the
+        # checkpoint's variable name (e.g. `FI` vs `z`).
+        param_levelist_to_name = {
+            (variable.param, variable.level): name for name, variable in self.typed_variables.items()
+        }
+
         def namer(field: ekd.Field, metadata: dict[str, Any]) -> str:
-            # TODO: Return the `namer` used when building the dataset
-            warnings.warn("🚧  TEMPORARY CODE 🚧: Use the remapping in the metadata")
             param, levelist, levtype = (
                 metadata.get("param"),
                 metadata.get("levelist"),
@@ -614,6 +620,10 @@ class Metadata(LegacyMixin):
             # Bug in eccodes that returns levelist for single level fields in GRIB2
             if levtype in ("sfc", "o2d"):
                 levelist = None
+
+            name = param_levelist_to_name.get((param, levelist))
+            if name is not None:
+                return name
 
             if levelist is None:
                 return param

--- a/src/anemoi/inference/metadata.py
+++ b/src/anemoi/inference/metadata.py
@@ -611,7 +611,7 @@ class Metadata(LegacyMixin):
             else:
                 param_levelist_to_name[key] = name
         for key in ambiguous_keys:
-            del param_levelist_to_name[key]
+            param_levelist_to_name.pop(key, None)
 
         def namer(field: ekd.Field, metadata: dict[str, Any]) -> str:
             param, levelist, levtype = (

--- a/src/anemoi/inference/metadata.py
+++ b/src/anemoi/inference/metadata.py
@@ -602,9 +602,16 @@ class Metadata(LegacyMixin):
         assert len(args) == 0, args
         assert len(kwargs) == 0, kwargs
 
-        param_levelist_to_name = {
-            (variable.param, variable.level): name for name, variable in self.typed_variables.items()
-        }
+        param_levelist_to_name: dict[tuple[Any, Any], str] = {}
+        ambiguous_keys: set[tuple[Any, Any]] = set()
+        for name, variable in self.typed_variables.items():
+            key = (variable.param, variable.level)
+            if key in param_levelist_to_name and param_levelist_to_name[key] != name:
+                ambiguous_keys.add(key)
+            else:
+                param_levelist_to_name[key] = name
+        for key in ambiguous_keys:
+            del param_levelist_to_name[key]
 
         def namer(field: ekd.Field, metadata: dict[str, Any]) -> str:
             param, levelist, levtype = (

--- a/src/anemoi/inference/testing/variables.py
+++ b/src/anemoi/inference/testing/variables.py
@@ -41,3 +41,24 @@ w_100 = Variable.from_dict(
         }
     },
 )
+
+z_renamed = Variable.from_dict(
+    "z",
+    {
+        "mars": {
+            "param": "FIS",
+            "levtype": "sfc",
+        }
+    },
+)
+
+z_100_renamed = Variable.from_dict(
+    "z_100",
+    {
+        "mars": {
+            "param": "FI",
+            "levtype": "pl",
+            "levelist": 100,
+        }
+    },
+)

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -9,10 +9,15 @@
 
 import pytest
 
+from anemoi.inference.metadata import Metadata
 from anemoi.inference.metadata import MetadataFactory
 from anemoi.inference.metadata import MultiDatasetMetadata
 from anemoi.inference.metadata import SingleDatasetMetadata
 from anemoi.inference.testing.mock_checkpoint import mock_load_metadata
+from anemoi.inference.testing.variables import w_100
+from anemoi.inference.testing.variables import z
+from anemoi.inference.testing.variables import z_100_renamed
+from anemoi.inference.testing.variables import z_renamed
 
 
 @pytest.mark.parametrize(
@@ -192,3 +197,46 @@ def test_open_dataset_args_kwargs_removes_unsupported_keys_multi_dataset():
     assert kwargs.get("dataset") == "test_dataset_multi"
     assert kwargs.get("start") == 2022
     assert kwargs.get("end") == 2022
+
+
+@pytest.mark.parametrize(
+    "typed_variables, field_metadata, expected_name",
+    [
+        # regular case: the GRIB `param` already matches the checkpoint variable name
+        pytest.param(
+            {"z": z},
+            {"param": "z", "levelist": None, "levtype": "sfc"},
+            "z",
+            id="regular-surface",
+        ),
+        pytest.param(
+            {"w_100": w_100},
+            {"param": "w", "levelist": 100, "levtype": "pl"},
+            "w_100",
+            id="regular-pressure",
+        ),
+        # renamed case: the GRIB `param` differs from the checkpoint variable name
+        pytest.param(
+            {"z": z_renamed},
+            {"param": "FIS", "levelist": None, "levtype": "sfc"},
+            "z",
+            id="renamed-surface",
+        ),
+        pytest.param(
+            {"z_100": z_100_renamed},
+            {"param": "FI", "levelist": 100, "levtype": "pl"},
+            "z_100",
+            id="renamed-pressure",
+        ),
+    ],
+)
+def test_default_namer(typed_variables, field_metadata, expected_name):
+    # Bypass Metadata.__init__ (which expects a real checkpoint) and set
+    # `typed_variables` directly: it's a cached_property, so assigning it on
+    # the instance overrides the cache.
+    metadata = Metadata.__new__(Metadata)
+    metadata.typed_variables = typed_variables
+
+    namer = metadata.default_namer()
+
+    assert namer(None, field_metadata) == expected_name

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -228,6 +228,15 @@ def test_open_dataset_args_kwargs_removes_unsupported_keys_multi_dataset():
             "z_100",
             id="renamed-pressure",
         ),
+        # ambiguous case: two different variable names share the same (param, level)
+        # key, so the override map must drop that key and fall back to the plain
+        # param name instead of arbitrarily picking one of the ambiguous names
+        pytest.param(
+            {"z": z, "z_alias": z},
+            {"param": "z", "levelist": None, "levtype": "sfc"},
+            "z",
+            id="ambiguous-collision-falls-back-to-param",
+        ),
     ],
 )
 def test_default_namer(typed_variables, field_metadata, expected_name):


### PR DESCRIPTION
## Description
Fixes GRIB field naming so it correctly maps back to the checkpoint's own variable names when the raw GRIB `param` doesn't match the checkpoint's internal naming (e.g. `FI` vs `z`).

## What problem does this change solve?
Bugfix. `Metadata.default_namer()` built field names by concatenating the raw GRIB `param`/`levelist` directly (e.g. `FI_100`), instead of resolving them against the checkpoint's own variable metadata. This caused a `KeyError: 'FI_100'` crash whenever a checkpoint's variable name (e.g. `z_100`) didn't match the raw param it was retrieved under (e.g. `FI`).

This adds a `(param, levelist) -> name` lookup built from the checkpoint's own `typed_variables` mars metadata, used before falling back to the old naming behavior.

A unit test (`test_default_namer` in `tests/unit/test_metadata.py`) was added, covering a regular and a renamed case for both a surface and a pressure-level field. The renamed example variables were added to `testing/variables.py`.

## What issue or task does this change relate to?
Fixes #571

## Additional notes
No changes to the fallback behavior for fields with no matching checkpoint variable. The original `param`/`levelist` concatenation is still used in that case.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
