### PR TITLE
feat(parallel output): configurable chunking strategies

### DIFF
--- a/docs/inference/parallel_output.rst
+++ b/docs/inference/parallel_output.rst
@@ -25,10 +25,11 @@ The ``parallel`` output wraps any other output type (e.g. ``grib``,
 ``zarr``, ``netcdf``) and:
 
 1. Spawns ``num_writers`` writer processes (using ``fork``).
-2. At each forecast step, splits the output fields evenly across the
-   writers.
-3. Each writer receives its chunk via a multiprocessing queue and writes
-   it using its own instance of the wrapped output.
+2. At each forecast step, splits the output fields into chunks according
+   to the configured :ref:`chunking strategy <parallel-output-chunking>`.
+3. Each chunk is dispatched to a writer process (round-robin when there
+   are more chunks than writers) via a multiprocessing queue, and written
+   using that writer's own instance of the wrapped output.
 4. On shutdown, all writers are gracefully terminated with a signal via
    their queues.
 
@@ -72,6 +73,94 @@ Parameters
 ==========
 
 .. automethod:: anemoi.inference.outputs.parallel.ParallelOutput.__init__
+
+.. _parallel-output-chunking:
+
+********************
+ Chunking Strategies
+********************
+
+At each forecast step, the output fields are divided into chunks that are
+distributed to the writer processes. The ``chunk_strategy`` parameter
+controls how this split is performed. If there are more chunks than
+writers, chunks are assigned to writers round-robin
+(chunk ``i`` goes to writer ``i % num_writers``).
+
+``by_worker`` (default)
+=======================
+
+Splits the fields into exactly ``num_writers`` contiguous chunks of
+roughly equal size, one per writer. This is the simplest strategy and a
+good default: each writer receives a comparable amount of work.
+
+.. code:: yaml
+
+   output:
+     parallel:
+       num_writers: 4
+       chunk_strategy: by_worker
+       output:
+         grib:
+           path: forecast.grib
+
+``by_size``
+===========
+
+Splits the fields into chunks of a fixed size, given by
+``fields_per_chunk``. The number of chunks depends on the number of
+output fields, and chunks are dispatched to writers round-robin. Use this
+when you want to control the amount of work per queue message (e.g. to
+bound memory usage), independently of ``num_writers``.
+
+.. code:: yaml
+
+   output:
+     parallel:
+       num_writers: 4
+       chunk_strategy:
+         by_size:
+           fields_per_chunk: 10
+       output:
+         grib:
+           path: forecast.grib
+
+``by_metadata``
+===============
+
+Groups fields into chunks by their metadata, so that all fields sharing
+the same value for the given ``keys`` are written by the same writer. The
+``keys`` are read from each variable's typed metadata (e.g. ``levtype``,
+``param``, ``level``). This is useful when the output backend benefits
+from co-locating related fields in the same file.
+
+.. code:: yaml
+
+   output:
+     parallel:
+       num_writers: 4
+       chunk_strategy:
+         by_metadata:
+           keys: [levtype]
+       output:
+         grib:
+           path: forecast.grib
+
+An optional ``max_groups`` argument caps the number of chunks produced;
+if more distinct metadata groups exist than ``max_groups``, groups are
+merged round-robin so that no more than ``max_groups`` chunks are created:
+
+.. code:: yaml
+
+   output:
+     parallel:
+       num_writers: 4
+       chunk_strategy:
+         by_metadata:
+           keys: [param]
+           max_groups: 8
+       output:
+         grib:
+           path: forecast.grib
 
 Examples
 ========

--- a/src/anemoi/inference/outputs/netcdf.py
+++ b/src/anemoi/inference/outputs/netcdf.py
@@ -181,15 +181,13 @@ class NetCDFOutput(Output):
             self.lon_var.units = "degrees_east"
             self.lon_var[:] = longitudes
 
-        # Time index is computed from the date, not incremented, so a forecast
-        # step delivered over several write_step calls maps to the same index.
-        # Index 0 is the first written step: the open() state (step zero) when
-        # write_step_zero is set, otherwise the first forecast step.
-        self.time_step_seconds = _output_timestep_seconds(self.metadata)
-        first_written = np.int64(_to_epoch_seconds(state["date"]))
-        if not self.write_step_zero:
-            first_written += np.int64(self.metadata.output_offsets[0].total_seconds())
-        self.time_index_reference = first_written
+        # Map each distinct output date to a time index. The index is derived
+        # from the date so that a forecast step
+        # delivered over several write_step calls - e.g. one chunk per call
+        # under a parallel output - always maps to the same index. Dates are
+        # assigned indices in first-seen order, which matches the sequential
+        # write order and makes no assumption about the output cadence.
+        self.time_indices: dict[datetime, int] = {}
         self.vars = {}
 
     def ensure_variables(self, state: State) -> None:
@@ -247,7 +245,7 @@ class NetCDFOutput(Output):
         date = np.int64(_to_epoch_seconds(state["date"]))
         step = date - self.reference_date
 
-        n = self._time_index(date)
+        n = self._time_index(state["date"])
 
         # update time coordinates
         self.period_var[n] = step
@@ -260,13 +258,19 @@ class NetCDFOutput(Output):
             with LOCK:
                 self.vars[name][n] = value
 
-    def _time_index(self, date: "np.int64") -> int:
+    def _time_index(self, date: datetime) -> int:
         """Return the time-dimension index for a given date (epoch seconds).
 
-        The index is computed from a fixed reference (the first written step)
-        so that repeated calls for the same forecast step target the same index.
+        Each distinct date is assigned an index in first-seen order; a date
+        that has already been written returns its existing index, so repeated
+        calls for the same forecast step target the same index.
         """
-        return int(round((date - self.time_index_reference) / self.time_step_seconds))
+        key = _to_epoch_seconds(date)
+        index = self.time_indices.get(key)
+        if index is None:
+            index = len(self.time_indices)
+            self.time_indices[key] = index
+        return index
 
     def close(self) -> None:
         """Close the NetCDF file."""
@@ -274,15 +278,6 @@ class NetCDFOutput(Output):
             with LOCK:
                 self.ncfile.close()
             self.ncfile = None
-
-
-def _output_timestep_seconds(metadata: Metadata) -> float:
-    """Return the spacing (in seconds) between consecutive output steps.
-
-    Output dates are uniformly spaced by the smallest output offset, which is
-    the model's effective output time step.
-    """
-    return min(offset.total_seconds() for offset in metadata.output_offsets)
 
 
 def _to_epoch_seconds(dt: datetime) -> int:

--- a/src/anemoi/inference/outputs/netcdf.py
+++ b/src/anemoi/inference/outputs/netcdf.py
@@ -181,7 +181,15 @@ class NetCDFOutput(Output):
             self.lon_var.units = "degrees_east"
             self.lon_var[:] = longitudes
 
-        self.n = 0
+        # Time index is computed from the date, not incremented, so a forecast
+        # step delivered over several write_step calls maps to the same index.
+        # Index 0 is the first written step: the open() state (step zero) when
+        # write_step_zero is set, otherwise the first forecast step.
+        self.time_step_seconds = _output_timestep_seconds(self.metadata)
+        first_written = np.int64(_to_epoch_seconds(state["date"]))
+        if not self.write_step_zero:
+            first_written += np.int64(self.metadata.output_offsets[0].total_seconds())
+        self.time_index_reference = first_written
         self.vars = {}
 
     def ensure_variables(self, state: State) -> None:
@@ -236,21 +244,29 @@ class NetCDFOutput(Output):
 
         self.ensure_variables(state)
 
-        step = np.int64(_to_epoch_seconds(state["date"])) - self.reference_date
+        date = np.int64(_to_epoch_seconds(state["date"]))
+        step = date - self.reference_date
+
+        n = self._time_index(date)
 
         # update time coordinates
-        self.period_var[self.n] = step
-        self.time_var[self.n] = self.reference_date + step
+        self.period_var[n] = step
+        self.time_var[n] = self.reference_date + step
 
         for name, value in state["fields"].items():
             if self.skip_variable(name):
                 continue
 
             with LOCK:
-                LOG.debug(f"🚧🚧🚧🚧🚧🚧 XXXXXX {name}, {self.n}, {value.shape}")
-                self.vars[name][self.n] = value
+                self.vars[name][n] = value
 
-        self.n += 1
+    def _time_index(self, date: "np.int64") -> int:
+        """Return the time-dimension index for a given date (epoch seconds).
+
+        The index is computed from a fixed reference (the first written step)
+        so that repeated calls for the same forecast step target the same index.
+        """
+        return int(round((date - self.time_index_reference) / self.time_step_seconds))
 
     def close(self) -> None:
         """Close the NetCDF file."""
@@ -258,6 +274,15 @@ class NetCDFOutput(Output):
             with LOCK:
                 self.ncfile.close()
             self.ncfile = None
+
+
+def _output_timestep_seconds(metadata: Metadata) -> float:
+    """Return the spacing (in seconds) between consecutive output steps.
+
+    Output dates are uniformly spaced by the smallest output offset, which is
+    the model's effective output time step.
+    """
+    return min(offset.total_seconds() for offset in metadata.output_offsets)
 
 
 def _to_epoch_seconds(dt: datetime) -> int:

--- a/src/anemoi/inference/outputs/parallel.py
+++ b/src/anemoi/inference/outputs/parallel.py
@@ -13,9 +13,16 @@ import math
 import multiprocessing as mp
 import os
 import traceback
+from collections.abc import Callable
+from collections.abc import Generator
 from enum import Enum
+from functools import cache
 from time import sleep
 from typing import Any
+from typing import Literal
+from typing import get_args
+
+from anemoi.transform.variables import Variable
 
 from anemoi.inference.context import Context
 from anemoi.inference.metadata import Metadata
@@ -168,25 +175,102 @@ def _restore_grib_templates(state: State) -> State:
     return state
 
 
-def _get_state_chunk(state: State, num_chunks: int, index: int) -> State:
-    """Get a specific chunk of a state along the fields dimension."""
-    if "fields" not in state:
-        raise ValueError("State dictionary must contain 'fields' key")
-    assert 0 <= index < num_chunks, f"Index {index} out of range for {num_chunks} chunks"
-    if num_chunks <= 1:
-        return state
+CHUNK_STRATEGIES = Literal["by_worker", "by_metadata", "by_size"]
+VALID_CHUNK_STRATEGIES = get_args(CHUNK_STRATEGIES)
 
-    # determine the subset of fields for this chunk
-    fields = state["fields"]
-    fields_per_chunk = math.ceil(len(fields) / num_chunks)
-    start = index * fields_per_chunk
-    stop = start + fields_per_chunk
 
-    # copy the subset of the fields into a new state dict
-    fields_subset = itertools.islice(fields.items(), start, stop)
-    chunk = state.copy()
-    chunk["fields"] = dict(fields_subset)
-    return chunk
+class Chunker:
+    """Chunking strategies for dividing the state into smaller parts for parallel outputting."""
+
+    def __init__(self, typed_variables: dict[str, Variable], num_writers: int):
+        """Chunker
+
+        Parameters
+        ----------
+        typed_variables : dict[str, Variable]
+            Dictionary of field name to its corresponding Variable metadata.
+        """
+        self.typed_variables = typed_variables
+        self.num_writers = num_writers
+
+    @cache
+    def _grouped_fields_by_metadata(self, keys: tuple[str], max_groups: int = -1) -> list[str]:
+        grouped_fields = {}
+        for field_name, meta in self.typed_variables.items():
+            key_tuple = tuple(getattr(meta, key, None) for key in keys)
+            grouped_fields.setdefault(key_tuple, []).append(field_name)
+        if len(grouped_fields) == 1:
+            LOG.warning(
+                "All fields have the same metadata for keys %s. Consider using different keys for chunking.", keys
+            )
+        else:
+            LOG.info(
+                "Fields have been grouped into %d distinct metadata combinations for keys %s.",
+                len(grouped_fields),
+                keys,
+            )
+
+        grouped_fields_list = list(grouped_fields.values())
+
+        if max_groups > 0 and len(grouped_fields) > max_groups:
+            new_grouped_fields = {}
+            for i, fields in enumerate(grouped_fields_list):
+                new_key = i % max_groups
+                new_grouped_fields.setdefault(new_key, []).extend(fields)
+            grouped_fields_list = list(new_grouped_fields.values())
+
+        return grouped_fields_list
+
+    def by_metadata(self, keys: list[str], max_groups: int = -1) -> Callable[[State], Generator[State, None, None]]:
+        """Chunk the state into smaller parts based on the specified metadata keys,
+        ensuring that variables with the same key=value pair are kept together in the same chunk.
+        """
+
+        def chunker(state: State) -> Generator[State, None, None]:
+            fields = state["fields"]
+            grouped_fields = self._grouped_fields_by_metadata(tuple(keys), max_groups=max_groups)
+
+            for group_keys in grouped_fields:
+                chunk = state.copy()
+                chunk["fields"] = {k: fields[k] for k in group_keys if k in fields}
+                yield chunk
+
+        return chunker
+
+    def by_size(self, fields_per_chunk: int) -> Callable[[State], Generator[State, None, None]]:
+        """Chunk the state into smaller parts, each containing a specified number of fields."""
+
+        def chunker(state: State) -> Generator[State, None, None]:
+            fields = state["fields"]
+            num_fields = len(fields)
+            for start in range(0, num_fields, fields_per_chunk):
+                stop = start + fields_per_chunk
+                chunk = state.copy()
+                fields_subset = itertools.islice(fields.items(), start, stop)
+                chunk["fields"] = dict(fields_subset)
+                yield chunk
+
+        return chunker
+
+    def by_worker(self) -> Callable[[State], Generator[State, None, None]]:
+        """Chunk the state into smaller parts, one for each worker."""
+
+        def chunker(state: State) -> Generator[State, None, None]:
+            fields = state["fields"]
+            fields_per_chunk = math.ceil(len(fields) / self.num_writers)
+
+            for i in range(self.num_writers):
+                chunk = state.copy()
+
+                start = i * fields_per_chunk
+                stop = start + fields_per_chunk
+
+                # copy the subset of the fields into a new state dict
+                fields_subset = itertools.islice(fields.items(), start, stop)
+                chunk["fields"] = dict(fields_subset)
+                yield chunk
+
+        return chunker
 
 
 class MessageType(str, Enum):
@@ -232,6 +316,7 @@ class ParallelOutput(Output):
         *,
         output: Output | Any | None = None,
         num_writers: int = 1,
+        chunk_strategy: CHUNK_STRATEGIES | dict[CHUNK_STRATEGIES, dict[str, Any]] = "by_worker",
         **kwargs: Any,
     ):
         """Initialise the ParallelOutput.
@@ -249,6 +334,14 @@ class ParallelOutput(Output):
             Number of writer processes to spawn.
             Must be >= 1.
             Defaults to 1 (single output file, asynchronous writes).
+        chunk_strategy : CHUNK_STRATEGIES | dict[CHUNK_STRATEGIES, dict[str, Any]], default="by_worker"
+            The strategy for chunking the output among writer processes.
+            Can be a string (one of "by_size", "by_metadata", "by_worker") or a dictionary
+            with a single key being the strategy name and the value being a dictionary of
+            keyword arguments for that strategy.
+            - `by_worker`, no additional arguments are needed.
+            - `by_size`, requires an additional argument `fields_per_chunk` specifying the number of fields per chunk.
+            - `by_metadata`, requires an additional argument `keys` specifying a list of metadata keys to keep in a chunk.
         **kwargs : Any
             Forwarded to the inner output.
         """
@@ -281,6 +374,32 @@ class ParallelOutput(Output):
         # (or once per rollout step, when the input pipeline reuses the same dict).
         self._grib_templates_bytes_cache_key: int | None = None
         self._grib_templates_bytes_cache_value: dict[str, bytes] | None = None
+
+        # Chunking strategy for dividing work among writer processes.
+        if not isinstance(chunk_strategy, (str, dict)):
+            raise ValueError("chunk_strategy must be a string or a dictionary")
+        if isinstance(chunk_strategy, dict) and len(chunk_strategy) != 1:
+            raise ValueError("chunk_strategy dictionary must have exactly one key")
+
+        chunk_strategy_name = chunk_strategy if isinstance(chunk_strategy, str) else next(iter(chunk_strategy.keys()))
+        chunk_strategy_init = next(iter(chunk_strategy.values())) if isinstance(chunk_strategy, dict) else {}
+        chunker = Chunker(self.metadata.typed_variables, self.num_writers)
+
+        match chunk_strategy_name:
+            case "by_size":
+                assert isinstance(chunk_strategy, dict)
+                chunking_func = chunker.by_size(**chunk_strategy_init)
+            case "by_metadata":
+                assert isinstance(chunk_strategy, dict)
+                chunking_func = chunker.by_metadata(**chunk_strategy_init)
+            case "by_worker":
+                chunking_func = chunker.by_worker()
+            case _:
+                raise ValueError(
+                    f"Invalid chunk_strategy: {chunk_strategy_name}. Must be one of {VALID_CHUNK_STRATEGIES}"
+                )
+
+        self.chunking_func = chunking_func
 
     def open(self, state: State) -> None:
         """Spawn the writer processes during open() instead of __init__() to ensure they have access to the full context.
@@ -319,10 +438,11 @@ class ParallelOutput(Output):
         Takes an optional 'message' argument to indicate the type of message being sent, which is used for control flow in the writer loop.
         """
         grib_templates_bytes = self._get_or_serialise_grib_templates(state)
-        for i in range(self.num_writers):
-            self._check_writer_alive(i)
-            chunk = _get_state_chunk(state, self.num_writers, i)
-            self._queues[i].put((_sanitise_state(chunk, grib_templates_bytes), message))
+
+        for i, chunk in enumerate(self.chunking_func(state)):
+            worker_id = i % self.num_writers
+            self._check_writer_alive(worker_id)
+            self._queues[worker_id].put((_sanitise_state(chunk, grib_templates_bytes), message))
 
     def _get_or_serialise_grib_templates(self, state: State) -> dict[str, bytes] | None:
         """Return the serialised GRIB templates bytes-map, serialising it on the first call.

--- a/src/anemoi/inference/outputs/parallel.py
+++ b/src/anemoi/inference/outputs/parallel.py
@@ -452,6 +452,22 @@ class ParallelOutput(Output):
         """
         grib_templates_bytes = self._get_or_serialise_grib_templates(state)
 
+        if message == MessageType.OPEN:
+            # Merge all chunked states per worker to create an initial OPEN message for each writer with the combined state.
+            merged_states = {}
+            for i, chunk in enumerate(self.chunking_func(state)):
+                worker_id = i % self.num_writers
+                if worker_id not in merged_states:
+                    merged_states[worker_id] = chunk
+                else:
+                    merged_states[worker_id]["fields"].update(chunk["fields"])
+
+            for worker_id, merged_state in merged_states.items():
+                if merged_state is not None:
+                    self._check_writer_alive(worker_id)
+                    self._queues[worker_id].put((_sanitise_state(merged_state, grib_templates_bytes), message))
+            return
+
         for i, chunk in enumerate(self.chunking_func(state)):
             worker_id = i % self.num_writers
             self._check_writer_alive(worker_id)

--- a/src/anemoi/inference/outputs/parallel.py
+++ b/src/anemoi/inference/outputs/parallel.py
@@ -194,14 +194,19 @@ class Chunker:
         self.num_writers = num_writers
 
     @cache
-    def _grouped_fields_by_metadata(self, keys: tuple[str], max_groups: int = -1) -> list[str]:
+    def _grouped_fields_by_metadata(
+        self, field_names: tuple[str, ...], keys: tuple[str, ...], max_groups: int = -1
+    ) -> list[list[str]]:
+        """Group the given field names by their metadata values for ``keys``."""
         grouped_fields = {}
-        for field_name, meta in self.typed_variables.items():
+        for field_name in field_names:
+            meta = self.typed_variables.get(field_name)
             key_tuple = tuple(getattr(meta, key, None) for key in keys)
             grouped_fields.setdefault(key_tuple, []).append(field_name)
         if len(grouped_fields) == 1:
             LOG.warning(
-                "All fields have the same metadata for keys %s. Consider using different keys for chunking.", keys
+                "All fields have the same metadata for keys %s. Consider using different keys for chunking.",
+                keys,
             )
         else:
             LOG.info(
@@ -228,17 +233,25 @@ class Chunker:
 
         def chunker(state: State) -> Generator[State, None, None]:
             fields = state["fields"]
-            grouped_fields = self._grouped_fields_by_metadata(tuple(keys), max_groups=max_groups)
+            grouped_fields = self._grouped_fields_by_metadata(tuple(fields.keys()), tuple(keys), max_groups=max_groups)
 
             for group_keys in grouped_fields:
+                chunk_fields = {k: fields[k] for k in group_keys if k in fields}
+                if not chunk_fields:
+                    # never yield an empty chunk
+                    continue
                 chunk = state.copy()
-                chunk["fields"] = {k: fields[k] for k in group_keys if k in fields}
+                chunk["fields"] = chunk_fields
                 yield chunk
 
         return chunker
 
     def by_size(self, fields_per_chunk: int) -> Callable[[State], Generator[State, None, None]]:
         """Chunk the state into smaller parts, each containing a specified number of fields."""
+        if not isinstance(fields_per_chunk, int) or isinstance(fields_per_chunk, bool):
+            raise TypeError("fields_per_chunk must be an integer.")
+        if fields_per_chunk <= 0:
+            raise ValueError("fields_per_chunk must be a positive integer.")
 
         def chunker(state: State) -> Generator[State, None, None]:
             fields = state["fields"]
@@ -383,7 +396,7 @@ class ParallelOutput(Output):
 
         chunk_strategy_name = chunk_strategy if isinstance(chunk_strategy, str) else next(iter(chunk_strategy.keys()))
         chunk_strategy_init = next(iter(chunk_strategy.values())) if isinstance(chunk_strategy, dict) else {}
-        chunker = Chunker(self.metadata.typed_variables, self.num_writers)
+        chunker = Chunker(self.typed_variables, self.num_writers)
 
         match chunk_strategy_name:
             case "by_size":

--- a/src/anemoi/inference/outputs/zarr.py
+++ b/src/anemoi/inference/outputs/zarr.py
@@ -216,12 +216,7 @@ class ZarrOutput(Output):
         if reference_date := getattr(self.context, "reference_date", None):
             self.reference_date = reference_date
 
-        # Date of the first written step, which maps to time index 0. This is
-        # the forecast start (step zero) when write_step_zero is set, otherwise
-        # the first forecast step.
-        self.time_index_reference = self.reference_date
         if not self.write_step_zero:
-            self.time_index_reference = self.reference_date + self.metadata.output_offsets[0]
             self.reference_date -= self.metadata.output_offsets[0]
 
         self.time_size = time
@@ -263,19 +258,28 @@ class ZarrOutput(Output):
             fill_value=self.missing_value,
         )
 
-        # Time index is computed from the date, not incremented, so a forecast
-        # step delivered over several write_step calls maps to the same index.
-        self.time_step_seconds = min(offset.total_seconds() for offset in self.metadata.output_offsets)
+        # Map each distinct output date to a time index. The index is derived
+        # from the date (not a per-call counter) so that a forecast step
+        # delivered over several write_step calls - e.g. one chunk per call
+        # under a parallel output - always maps to the same index. Dates are
+        # assigned indices in first-seen order, which matches the sequential
+        # write order and makes no assumption about the output cadence.
+        self.time_indices: dict[datetime.datetime, int] = {}
         self.latitude_var[:] = latitudes
         self.longitude_var[:] = longitudes
 
     def _time_index(self, date: "datetime.datetime") -> int:
         """Return the time-dimension index for a given date.
 
-        The index is computed from a fixed reference (the first written step)
-        so that repeated calls for the same forecast step target the same index.
+        Each distinct date is assigned an index in first-seen order; a date
+        that has already been written returns its existing index, so repeated
+        calls for the same forecast step target the same index.
         """
-        return int(round((date - self.time_index_reference).total_seconds() / self.time_step_seconds))
+        index = self.time_indices.get(date)
+        if index is None:
+            index = len(self.time_indices)
+            self.time_indices[date] = index
+        return index
 
     def _variable_array(self, name: str, values_size: int) -> Any:
         """Get the variable array by name.

--- a/src/anemoi/inference/outputs/zarr.py
+++ b/src/anemoi/inference/outputs/zarr.py
@@ -9,6 +9,7 @@
 
 from __future__ import annotations
 
+import datetime
 import logging
 import math
 import shutil
@@ -215,7 +216,12 @@ class ZarrOutput(Output):
         if reference_date := getattr(self.context, "reference_date", None):
             self.reference_date = reference_date
 
+        # Date of the first written step, which maps to time index 0. This is
+        # the forecast start (step zero) when write_step_zero is set, otherwise
+        # the first forecast step.
+        self.time_index_reference = self.reference_date
         if not self.write_step_zero:
+            self.time_index_reference = self.reference_date + self.metadata.output_offsets[0]
             self.reference_date -= self.metadata.output_offsets[0]
 
         self.time_size = time
@@ -257,9 +263,19 @@ class ZarrOutput(Output):
             fill_value=self.missing_value,
         )
 
-        self.n = 0
+        # Time index is computed from the date, not incremented, so a forecast
+        # step delivered over several write_step calls maps to the same index.
+        self.time_step_seconds = min(offset.total_seconds() for offset in self.metadata.output_offsets)
         self.latitude_var[:] = latitudes
         self.longitude_var[:] = longitudes
+
+    def _time_index(self, date: "datetime.datetime") -> int:
+        """Return the time-dimension index for a given date.
+
+        The index is computed from a fixed reference (the first written step)
+        so that repeated calls for the same forecast step target the same index.
+        """
+        return int(round((date - self.time_index_reference).total_seconds() / self.time_step_seconds))
 
     def _variable_array(self, name: str, values_size: int) -> Any:
         """Get the variable array by name.
@@ -310,16 +326,17 @@ class ZarrOutput(Output):
             The state dictionary.
         """
         step = state["date"] - self.reference_date
-        self.time_array[self.n] = step.total_seconds()
+
+        n = self._time_index(state["date"])
+
+        self.time_array[n] = step.total_seconds()
 
         values = len(state["latitudes"])
 
         for name, value in state["fields"].items():
             if self.skip_variable(name):
                 continue
-            self._variable_array(name, values)[self.n] = value
-
-        self.n += 1
+            self._variable_array(name, values)[n] = value
 
     def close(self) -> None:
         """Close the Zarr file."""

--- a/tests/unit/outputs/test_parallel.py
+++ b/tests/unit/outputs/test_parallel.py
@@ -10,16 +10,18 @@
 import datetime
 import re
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
 
 from anemoi.inference.decorators import supports_parallel_output
+from anemoi.inference.outputs.parallel import VALID_CHUNK_STRATEGIES
+from anemoi.inference.outputs.parallel import Chunker
 from anemoi.inference.outputs.parallel import MessageType
 from anemoi.inference.outputs.parallel import ParallelOutput
 from anemoi.inference.outputs.parallel import _detach_tensors
-from anemoi.inference.outputs.parallel import _get_state_chunk
 from anemoi.inference.outputs.parallel import _sanitise_state
 from anemoi.inference.outputs.printer import PrinterOutput
 
@@ -27,13 +29,31 @@ from anemoi.inference.outputs.printer import PrinterOutput
 
 
 def _make_state(n_fields, extra=None):
-    state = {"fields": {f"field_{i}": np.array([float(i)]) for i in range(n_fields)}, "date": "2020-01-01"}
+    state = {
+        "fields": {f"field_{i}": np.array([float(i)]) for i in range(n_fields)},
+        "date": "2020-01-01",
+    }
     if extra:
         state.update(extra)
     return state
 
 
-def _make_context_and_metadata():
+def _make_typed_variables(n_fields, **attrs):
+    """Build a ``{name: Variable-like}`` mapping matching ``_make_state`` field names.
+
+    The chunker only ever reads attributes off the variable objects via
+    ``getattr(meta, key, None)``, so a lightweight ``SimpleNamespace`` is a faithful
+    stand-in for :class:`anemoi.transform.variables.Variable` here. Per-field
+    attribute values can be supplied as ``attr=[v0, v1, ...]`` lists.
+    """
+    typed = {}
+    for i in range(n_fields):
+        kwargs = {k: v[i] for k, v in attrs.items()}
+        typed[f"field_{i}"] = SimpleNamespace(**kwargs)
+    return typed
+
+
+def _make_context_and_metadata(typed_variables=None):
     context = MagicMock()
     context.reference_date = "2020-01-01"
     context.typed_variables = {}
@@ -42,7 +62,7 @@ def _make_context_and_metadata():
 
     metadata = MagicMock()
     metadata.dataset_name = "test"
-    metadata.typed_variables = {}
+    metadata.typed_variables = typed_variables if typed_variables is not None else {}
     return context, metadata
 
 
@@ -89,10 +109,13 @@ def _run_sequential(context, metadata, path, states):
     return _parse_printer_output(path)
 
 
-def _run_parallel(context, metadata, path, states, num_writers):
+def _run_parallel(context, metadata, path, states, num_writers, chunk_strategy=None):
     """Write states through ParallelOutput wrapping PrinterOutput."""
     config = {"printer": {"path": str(path), "max_lines": 0}}
-    po = ParallelOutput(context, metadata, output=config, num_writers=num_writers)
+    kwargs = {}
+    if chunk_strategy is not None:
+        kwargs["chunk_strategy"] = chunk_strategy
+    po = ParallelOutput(context, metadata, output=config, num_writers=num_writers, **kwargs)
     po.open(states[0])
     for state in states:
         po.write_state(state)
@@ -192,6 +215,39 @@ class TestParallelOutputCorrectness:
             p = base.with_stem(base.stem + f"_w{i}")
             assert p.exists(), f"Writer {i} did not produce a file at {p}"
 
+    def test_by_size_strategy_matches_sequential(self, tmp_path):
+        context, metadata = _make_context_and_metadata()
+        states = [_make_state(7, {"step": datetime.timedelta(hours=h)}) for h in range(2)]
+
+        seq = _run_sequential(context, metadata, tmp_path / "seq.txt", states)
+        par = _run_parallel(
+            context,
+            metadata,
+            tmp_path / "par.txt",
+            states,
+            num_writers=2,
+            chunk_strategy={"by_size": {"fields_per_chunk": 2}},
+        )
+
+        assert _records_equal(seq, par), "by_size strategy differs from sequential"
+
+    def test_by_metadata_strategy_matches_sequential(self, tmp_path):
+        typed = _make_typed_variables(6, levtype=["sfc", "pl", "sfc", "pl", "sfc", "pl"])
+        context, metadata = _make_context_and_metadata(typed)
+        states = [_make_state(6, {"step": datetime.timedelta(hours=h)}) for h in range(2)]
+
+        seq = _run_sequential(context, metadata, tmp_path / "seq.txt", states)
+        par = _run_parallel(
+            context,
+            metadata,
+            tmp_path / "par.txt",
+            states,
+            num_writers=2,
+            chunk_strategy={"by_metadata": {"keys": ["levtype"]}},
+        )
+
+        assert _records_equal(seq, par), "by_metadata strategy differs from sequential"
+
 
 # ── _detach_tensors ───────────────────────────────────────────────────────────
 
@@ -264,89 +320,200 @@ class TestSanitiseState:
         assert "fields" in result
 
 
-# ── _get_state_chunk ──────────────────────────────────────────────────────────
+# ── Chunker.by_worker ─────────────────────────────────────────────────────────
 
 
-class TestGetStateChunk:
-    def test_single_chunk_returns_full_state(self):
-        state = _make_state(6)
-        chunk = _get_state_chunk(state, num_chunks=1, index=0)
-        assert chunk is state
+def _chunk_field_sets(chunker_fn, state):
+    """Return the list of field-name sets produced by a chunking function."""
+    return [set(chunk["fields"].keys()) for chunk in chunker_fn(state)]
 
-    def test_two_chunks_split_evenly(self):
-        state = _make_state(6)
-        c0 = _get_state_chunk(state, 2, 0)
-        c1 = _get_state_chunk(state, 2, 1)
+
+class TestChunkerByWorker:
+    def test_single_worker_yields_one_full_chunk(self):
+        chunker = Chunker({}, num_writers=1)
+        chunks = list(chunker.by_worker()(_make_state(6)))
+        assert len(chunks) == 1
+        assert list(chunks[0]["fields"].keys()) == [f"field_{i}" for i in range(6)]
+
+    def test_yields_one_chunk_per_worker(self):
+        chunker = Chunker({}, num_writers=3)
+        chunks = list(chunker.by_worker()(_make_state(6)))
+        assert len(chunks) == 3
+
+    def test_two_workers_split_evenly(self):
+        chunker = Chunker({}, num_writers=2)
+        c0, c1 = list(chunker.by_worker()(_make_state(6)))
         assert list(c0["fields"].keys()) == ["field_0", "field_1", "field_2"]
         assert list(c1["fields"].keys()) == ["field_3", "field_4", "field_5"]
 
     def test_chunks_cover_all_fields(self):
         state = _make_state(10)
-        all_fields = set()
-        for i in range(4):
-            chunk = _get_state_chunk(state, 4, i)
-            all_fields.update(chunk["fields"].keys())
-        assert all_fields == set(state["fields"].keys())
+        sets = _chunk_field_sets(Chunker({}, num_writers=4).by_worker(), state)
+        assert set().union(*sets) == set(state["fields"].keys())
 
     def test_chunks_are_disjoint(self):
         state = _make_state(12)
-        chunks = [_get_state_chunk(state, 4, i) for i in range(4)]
-        seen = []
-        for chunk in chunks:
-            for k in chunk["fields"]:
-                assert k not in seen, f"{k} appears in more than one chunk"
-                seen.append(k)
+        sets = _chunk_field_sets(Chunker({}, num_writers=4).by_worker(), state)
+        seen = set()
+        for s in sets:
+            assert seen.isdisjoint(s)
+            seen |= s
 
     def test_uneven_split(self):
         state = _make_state(7)
-        sizes = [len(_get_state_chunk(state, 3, i)["fields"]) for i in range(3)]
+        sizes = [len(s) for s in _chunk_field_sets(Chunker({}, num_writers=3).by_worker(), state)]
         assert sum(sizes) == 7
         assert sizes == [3, 3, 1]
 
-    def test_single_field(self):
-        state = _make_state(1)
-        c0 = _get_state_chunk(state, 2, 0)
-        c1 = _get_state_chunk(state, 2, 1)
-        assert len(c0["fields"]) == 1
-        assert len(c1["fields"]) == 0
-
-    def test_more_writers_than_fields(self):
+    def test_more_workers_than_fields_gives_empty_chunks(self):
         state = _make_state(2)
-        sizes = [len(_get_state_chunk(state, 4, i)["fields"]) for i in range(4)]
+        sizes = [len(s) for s in _chunk_field_sets(Chunker({}, num_writers=4).by_worker(), state)]
         assert sum(sizes) == 2
+        # 4 chunks are always yielded, one per worker, some empty
+        assert len(sizes) == 4
+        assert sizes.count(0) == 2
 
     def test_non_field_keys_preserved_in_all_chunks(self):
         state = _make_state(6, {"step": 12, "date": "2020-01-01"})
-        for i in range(3):
-            chunk = _get_state_chunk(state, 3, i)
+        for chunk in Chunker({}, num_writers=3).by_worker()(state):
             assert chunk["step"] == 12
             assert chunk["date"] == "2020-01-01"
 
     def test_chunk_is_shallow_copy_of_state(self):
         state = _make_state(4)
-        chunk = _get_state_chunk(state, 2, 0)
+        chunk = next(Chunker({}, num_writers=2).by_worker()(state))
         assert chunk is not state
         assert chunk["fields"] is not state["fields"]
 
-    def test_missing_fields_raises(self):
-        with pytest.raises(ValueError, match="fields"):
-            _get_state_chunk({"date": "2020-01-01"}, 2, 0)
 
-    def test_index_out_of_range_raises(self):
-        state = _make_state(4)
-        with pytest.raises(AssertionError):
-            _get_state_chunk(state, 2, 5)
+# ── Chunker.by_size ───────────────────────────────────────────────────────────
 
-    def test_negative_index_raises(self):
+
+class TestChunkerBySize:
+    def test_exact_multiple(self):
+        state = _make_state(6)
+        sizes = [len(s) for s in _chunk_field_sets(Chunker({}, num_writers=2).by_size(2), state)]
+        assert sizes == [2, 2, 2]
+
+    def test_remainder_in_last_chunk(self):
+        state = _make_state(7)
+        sizes = [len(s) for s in _chunk_field_sets(Chunker({}, num_writers=2).by_size(3), state)]
+        assert sizes == [3, 3, 1]
+
+    def test_chunk_larger_than_num_fields(self):
         state = _make_state(4)
-        with pytest.raises(AssertionError):
-            _get_state_chunk(state, 2, -1)
+        chunks = list(Chunker({}, num_writers=2).by_size(10)(state))
+        assert len(chunks) == 1
+        assert len(chunks[0]["fields"]) == 4
+
+    def test_size_one(self):
+        state = _make_state(3)
+        sizes = [len(s) for s in _chunk_field_sets(Chunker({}, num_writers=2).by_size(1), state)]
+        assert sizes == [1, 1, 1]
+
+    def test_chunks_cover_all_fields_in_order(self):
+        state = _make_state(5)
+        names = []
+        for chunk in Chunker({}, num_writers=2).by_size(2)(state):
+            names.extend(chunk["fields"].keys())
+        assert names == [f"field_{i}" for i in range(5)]
+
+    def test_non_field_keys_preserved(self):
+        state = _make_state(4, {"step": 12})
+        for chunk in Chunker({}, num_writers=2).by_size(2)(state):
+            assert chunk["step"] == 12
+
+
+# ── Chunker.by_metadata ───────────────────────────────────────────────────────
+
+
+class TestChunkerByMetadata:
+    def test_groups_by_single_key(self):
+        # levtype: sfc, sfc, pl, pl -> two groups
+        typed = _make_typed_variables(4, levtype=["sfc", "sfc", "pl", "pl"])
+        chunker = Chunker(typed, num_writers=2)
+        sets = _chunk_field_sets(chunker.by_metadata(["levtype"]), _make_state(4))
+        assert {frozenset(s) for s in sets} == {
+            frozenset({"field_0", "field_1"}),
+            frozenset({"field_2", "field_3"}),
+        }
+
+    def test_groups_by_multiple_keys(self):
+        typed = _make_typed_variables(
+            4,
+            levtype=["pl", "pl", "pl", "pl"],
+            level=[500, 500, 850, 850],
+        )
+        chunker = Chunker(typed, num_writers=2)
+        sets = _chunk_field_sets(chunker.by_metadata(["levtype", "level"]), _make_state(4))
+        assert {frozenset(s) for s in sets} == {
+            frozenset({"field_0", "field_1"}),
+            frozenset({"field_2", "field_3"}),
+        }
+
+    def test_all_same_metadata_single_group(self):
+        typed = _make_typed_variables(4, levtype=["sfc", "sfc", "sfc", "sfc"])
+        chunker = Chunker(typed, num_writers=2)
+        chunks = list(chunker.by_metadata(["levtype"])(_make_state(4)))
+        assert len(chunks) == 1
+        assert len(chunks[0]["fields"]) == 4
+
+    def test_all_distinct_metadata_one_group_each(self):
+        typed = _make_typed_variables(3, level=[100, 200, 300])
+        chunker = Chunker(typed, num_writers=2)
+        sizes = [len(s) for s in _chunk_field_sets(chunker.by_metadata(["level"]), _make_state(3))]
+        assert sizes == [1, 1, 1]
+
+    def test_covers_all_fields(self):
+        typed = _make_typed_variables(4, levtype=["sfc", "pl", "sfc", "pl"])
+        chunker = Chunker(typed, num_writers=2)
+        sets = _chunk_field_sets(chunker.by_metadata(["levtype"]), _make_state(4))
+        assert set().union(*sets) == {f"field_{i}" for i in range(4)}
+
+    def test_max_groups_caps_number_of_chunks(self):
+        # 4 distinct levels -> 4 groups, capped to 2
+        typed = _make_typed_variables(4, level=[100, 200, 300, 400])
+        chunker = Chunker(typed, num_writers=2)
+        sets = _chunk_field_sets(chunker.by_metadata(["level"], max_groups=2), _make_state(4))
+        assert len(sets) == 2
+        # every field still present exactly once
+        assert set().union(*sets) == {f"field_{i}" for i in range(4)}
+        seen = set()
+        for s in sets:
+            assert seen.isdisjoint(s)
+            seen |= s
+
+    def test_max_groups_larger_than_groups_is_noop(self):
+        typed = _make_typed_variables(4, levtype=["sfc", "sfc", "pl", "pl"])
+        chunker = Chunker(typed, num_writers=2)
+        sets = _chunk_field_sets(chunker.by_metadata(["levtype"], max_groups=10), _make_state(4))
+        assert len(sets) == 2
+
+    def test_missing_attribute_treated_as_none(self):
+        # field_0 has no 'level' attribute -> grouped under None; field_1 has level 500
+        typed = {
+            "field_0": SimpleNamespace(),
+            "field_1": SimpleNamespace(level=500),
+        }
+        chunker = Chunker(typed, num_writers=2)
+        sets = _chunk_field_sets(chunker.by_metadata(["level"]), _make_state(2))
+        assert {frozenset(s) for s in sets} == {
+            frozenset({"field_0"}),
+            frozenset({"field_1"}),
+        }
+
+    def test_result_is_cached(self):
+        typed = _make_typed_variables(2, levtype=["sfc", "pl"])
+        chunker = Chunker(typed, num_writers=2)
+        first = chunker._grouped_fields_by_metadata(("levtype",))
+        second = chunker._grouped_fields_by_metadata(("levtype",))
+        assert first is second
 
 
 # ── ParallelOutput (unit, no subprocesses) ────────────────────────────────────
 
 
-def _make_parallel_output(num_writers=2):
+def _make_parallel_output(num_writers=2, chunking_func=None):
     context, metadata = _make_context_and_metadata()
     po = ParallelOutput.__new__(ParallelOutput)
     po.context = context
@@ -362,6 +529,10 @@ def _make_parallel_output(num_writers=2):
     po.typed_variables = {}
     po.dataset_name = "test"
     po.reference_date = "2020-01-01"
+    po._grib_templates_bytes_cache_key = None
+    po._grib_templates_bytes_cache_value = None
+    # default to one-chunk-per-worker, matching the "by_worker" strategy
+    po.chunking_func = chunking_func or Chunker({}, num_writers).by_worker()
     return po
 
 
@@ -417,6 +588,49 @@ class TestParallelOutputDispatch:
         args, _ = po._queues[0].put.call_args
         _, msg_type = args[0]
         assert msg_type == MessageType.INITIAL_STATE
+
+    def test_more_chunks_than_writers_round_robins(self):
+        """When the strategy yields more chunks than writers, chunks are
+        distributed round-robin (chunk i -> writer i % num_writers).
+        """
+        # by_size(1) on 5 fields with 2 writers => 5 chunks: w0,w1,w0,w1,w0
+        po = _make_parallel_output(num_writers=2, chunking_func=Chunker({}, 2).by_size(1))
+        po._queues, po._processes = self._make_queues_and_processes(2)
+        state = _make_state(5)
+        po.dispatch_state_to_writers(state, message=MessageType.STATE)
+
+        assert po._queues[0].put.call_count == 3
+        assert po._queues[1].put.call_count == 2
+
+        received = set()
+        for q in po._queues:
+            for call in q.put.call_args_list:
+                payload, _ = call.args[0]
+                received |= set(payload["fields"].keys())
+        assert received == set(state["fields"].keys())
+
+    def test_all_fields_dispatched_exactly_once(self):
+        po = _make_parallel_output(num_writers=3)
+        po._queues, po._processes = self._make_queues_and_processes(3)
+        state = _make_state(7)
+        po.dispatch_state_to_writers(state, message=MessageType.STATE)
+
+        from collections import Counter
+
+        counts = Counter()
+        for q in po._queues:
+            for call in q.put.call_args_list:
+                payload, _ = call.args[0]
+                counts.update(payload["fields"].keys())
+        assert set(counts) == set(state["fields"].keys())
+        assert all(c == 1 for c in counts.values())
+
+    def test_dead_writer_short_circuits_dispatch(self):
+        po = _make_parallel_output(num_writers=2)
+        po._queues, po._processes = self._make_queues_and_processes(2)
+        po._processes[0].is_alive.return_value = False
+        with pytest.raises(RuntimeError, match="Writer 0 is dead"):
+            po.dispatch_state_to_writers(_make_state(4), message=MessageType.STATE)
 
 
 class TestParallelOutputWriterAliveCheck:
@@ -476,6 +690,62 @@ class TestParallelOutputInit:
         po = self._make(num_writers=2, output={"recording": {"path": "out.json"}})
         assert "ParallelOutput" in repr(po)
         assert "num_writers=2" in repr(po)
+
+
+class TestParallelOutputChunkStrategy:
+    def _make(self, **kwargs):
+        context, metadata = _make_context_and_metadata(kwargs.pop("typed_variables", None))
+        kwargs.setdefault("output", {"recording": {"path": "out.json"}})
+        return ParallelOutput(context, metadata, **kwargs)
+
+    def test_default_strategy_is_by_worker(self):
+        po = self._make(num_writers=2)
+        # by_worker yields exactly one chunk per writer
+        chunks = list(po.chunking_func(_make_state(6)))
+        assert len(chunks) == po.num_writers
+
+    def test_valid_strategies_constant(self):
+        assert set(VALID_CHUNK_STRATEGIES) == {"by_worker", "by_metadata", "by_size"}
+
+    def test_by_worker_string(self):
+        po = self._make(num_writers=3, chunk_strategy="by_worker")
+        assert len(list(po.chunking_func(_make_state(6)))) == 3
+
+    def test_by_size_dict(self):
+        po = self._make(num_writers=2, chunk_strategy={"by_size": {"fields_per_chunk": 2}})
+        sizes = [len(c["fields"]) for c in po.chunking_func(_make_state(6))]
+        assert sizes == [2, 2, 2]
+
+    def test_by_metadata_dict(self):
+        typed = _make_typed_variables(4, levtype=["sfc", "sfc", "pl", "pl"])
+        po = self._make(
+            num_writers=2,
+            typed_variables=typed,
+            chunk_strategy={"by_metadata": {"keys": ["levtype"]}},
+        )
+        sizes = sorted(len(c["fields"]) for c in po.chunking_func(_make_state(4)))
+        assert sizes == [2, 2]
+
+    def test_invalid_strategy_name_string_raises(self):
+        with pytest.raises(ValueError, match="Invalid chunk_strategy"):
+            self._make(chunk_strategy="by_nonsense")
+
+    def test_invalid_strategy_name_dict_raises(self):
+        with pytest.raises(ValueError, match="Invalid chunk_strategy"):
+            self._make(chunk_strategy={"by_nonsense": {}})
+
+    def test_wrong_type_raises(self):
+        with pytest.raises(ValueError, match="must be a string or a dictionary"):
+            self._make(chunk_strategy=123)
+
+    def test_dict_with_multiple_keys_raises(self):
+        with pytest.raises(ValueError, match="exactly one key"):
+            self._make(chunk_strategy={"by_size": {"fields_per_chunk": 2}, "by_worker": {}})
+
+    def test_by_size_missing_param_raises(self):
+        # by_size requires 'fields_per_chunk'
+        with pytest.raises(TypeError):
+            self._make(chunk_strategy={"by_size": {}})
 
 
 # ── supports_parallel_output ──────────────────────────────────────────────────
@@ -564,14 +834,17 @@ class TestSupportsParallelOutputDecorator:
 
     def test_multiple_args_applied(self):
         obj = self._make_cls("path", "archive_requests.path")(
-            path="out.grib", archive_requests={"path": "out.json"}, **{"_parallel-output-suffix": "_w0"}
+            path="out.grib",
+            archive_requests={"path": "out.json"},
+            **{"_parallel-output-suffix": "_w0"},
         )
         assert obj.path == "out_w0.grib"
         assert obj.archive_requests["path"] == "out_w0.json"
 
     def test_deep_nested_suffix_applied(self):
         obj = self._make_cls("archive_requests.sub.path")(
-            archive_requests={"sub": {"path": "out.json"}}, **{"_parallel-output-suffix": "_w0"}
+            archive_requests={"sub": {"path": "out.json"}},
+            **{"_parallel-output-suffix": "_w0"},
         )
         assert obj.archive_requests["sub"]["path"] == "out_w0.json"
 

--- a/tests/unit/outputs/test_parallel.py
+++ b/tests/unit/outputs/test_parallel.py
@@ -510,6 +510,52 @@ class TestChunkerByMetadata:
         second = chunker._grouped_fields_by_metadata(field_names, ("levtype",))
         assert first is second
 
+    def test_field_absent_from_typed_variables_is_not_dropped(self):
+        # Only field_0 has metadata; field_1 is context-defined (absent from typed variables). It must still be chunked, grouped under None.
+        typed = {"field_0": SimpleNamespace(levtype="pl")}
+        chunker = Chunker(typed, num_writers=2)
+        sets = _chunk_field_sets(chunker.by_metadata(["levtype"]), _make_state(2))
+        assert set().union(*sets) == {"field_0", "field_1"}
+        assert {frozenset(s) for s in sets} == {
+            frozenset({"field_0"}),
+            frozenset({"field_1"}),
+        }
+
+    def test_all_fields_covered_when_none_have_metadata(self):
+        # No field has metadata at all -> single None group with every field.
+        chunker = Chunker({}, num_writers=2)
+        state = _make_state(4)
+        chunks = list(chunker.by_metadata(["levtype"])(state))
+        assert len(chunks) == 1
+        assert set(chunks[0]["fields"].keys()) == set(state["fields"].keys())
+
+    def test_no_empty_chunks_when_typed_variables_has_extra_fields(self):
+        # The typed variables references fields not present in the state; those metadata-only groups must not produce empty chunks.
+        typed = _make_typed_variables(6, levtype=["sfc", "sfc", "pl", "pl", "ml", "ml"])
+        chunker = Chunker(typed, num_writers=2)
+        # state only contains the first two fields (both "sfc")
+        state = _make_state(2)
+        chunks = list(chunker.by_metadata(["levtype"])(state))
+        assert all(len(c["fields"]) > 0 for c in chunks)
+        assert len(chunks) == 1
+        assert set(chunks[0]["fields"].keys()) == {"field_0", "field_1"}
+
+    def test_grouping_driven_by_state_fields(self):
+        # A field's group is determined by looking up its metadata for the
+        # fields actually in the state, not by iterating typed_variables.
+        typed = _make_typed_variables(4, levtype=["sfc", "pl", "sfc", "pl"])
+        chunker = Chunker(typed, num_writers=2)
+        # only field_1 (pl) and field_2 (sfc) are in the state
+        state = {
+            "fields": {"field_1": np.array([1.0]), "field_2": np.array([2.0])},
+            "date": "2020-01-01",
+        }
+        sets = _chunk_field_sets(chunker.by_metadata(["levtype"]), state)
+        assert {frozenset(s) for s in sets} == {
+            frozenset({"field_1"}),
+            frozenset({"field_2"}),
+        }
+
 
 # ── ParallelOutput (unit, no subprocesses) ────────────────────────────────────
 
@@ -632,6 +678,94 @@ class TestParallelOutputDispatch:
         po._processes[0].is_alive.return_value = False
         with pytest.raises(RuntimeError, match="Writer 0 is dead"):
             po.dispatch_state_to_writers(_make_state(4), message=MessageType.STATE)
+
+
+class TestParallelOutputOpenMerge:
+    """The OPEN message must arrive exactly once per writer, with that writer's
+    chunks merged, so stateful backends see a single logical open() per step.
+    """
+
+    def _make_queues_and_processes(self, num_writers, alive=True):
+        queues = [MagicMock() for _ in range(num_writers)]
+        processes = [MagicMock() for _ in range(num_writers)]
+        for p in processes:
+            p.is_alive.return_value = alive
+        return queues, processes
+
+    def _received_per_writer(self, po):
+        """Return list of (message_type, field-name set) per put call, per writer."""
+        result = []
+        for q in po._queues:
+            calls = []
+            for call in q.put.call_args_list:
+                payload, msg_type = call.args[0]
+                calls.append((msg_type, set(payload["fields"].keys())))
+            result.append(calls)
+        return result
+
+    def test_open_sends_one_message_per_writer_even_with_more_chunks(self):
+        # by_size(1) on 5 fields, 2 writers -> 5 chunks round-robin, but OPEN
+        # must be merged into a single message per writer.
+        po = _make_parallel_output(num_writers=2, chunking_func=Chunker({}, 2).by_size(1))
+        po._queues, po._processes = self._make_queues_and_processes(2)
+        po.dispatch_state_to_writers(_make_state(5), message=MessageType.OPEN)
+
+        assert po._queues[0].put.call_count == 1
+        assert po._queues[1].put.call_count == 1
+
+    def test_open_merges_worker_chunks(self):
+        po = _make_parallel_output(num_writers=2, chunking_func=Chunker({}, 2).by_size(1))
+        po._queues, po._processes = self._make_queues_and_processes(2)
+        state = _make_state(5)
+        po.dispatch_state_to_writers(state, message=MessageType.OPEN)
+
+        per_writer = self._received_per_writer(po)
+        # chunks 0,2,4 -> writer 0 ; chunks 1,3 -> writer 1
+        assert per_writer[0] == [(MessageType.OPEN, {"field_0", "field_2", "field_4"})]
+        assert per_writer[1] == [(MessageType.OPEN, {"field_1", "field_3"})]
+
+    def test_open_covers_all_fields_exactly_once(self):
+        po = _make_parallel_output(num_writers=3, chunking_func=Chunker({}, 3).by_size(1))
+        po._queues, po._processes = self._make_queues_and_processes(3)
+        state = _make_state(7)
+        po.dispatch_state_to_writers(state, message=MessageType.OPEN)
+
+        from collections import Counter
+
+        counts = Counter()
+        for q in po._queues:
+            assert q.put.call_count == 1  # one merged OPEN per writer
+            payload, msg_type = q.put.call_args.args[0]
+            assert msg_type == MessageType.OPEN
+            counts.update(payload["fields"].keys())
+        assert set(counts) == set(state["fields"].keys())
+        assert all(c == 1 for c in counts.values())
+
+    def test_open_by_worker_one_message_per_writer(self):
+        po = _make_parallel_output(num_writers=2, chunking_func=Chunker({}, 2).by_worker())
+        po._queues, po._processes = self._make_queues_and_processes(2)
+        po.dispatch_state_to_writers(_make_state(4), message=MessageType.OPEN)
+        for q in po._queues:
+            assert q.put.call_count == 1
+            _, msg_type = q.put.call_args.args[0]
+            assert msg_type == MessageType.OPEN
+
+    def test_open_checks_writer_alive(self):
+        po = _make_parallel_output(num_writers=2, chunking_func=Chunker({}, 2).by_size(1))
+        po._queues, po._processes = self._make_queues_and_processes(2)
+        po._processes[1].is_alive.return_value = False
+        with pytest.raises(RuntimeError, match="Writer 1 is dead"):
+            po.dispatch_state_to_writers(_make_state(4), message=MessageType.OPEN)
+
+    def test_open_method_dispatches_open_message(self):
+        po = _make_parallel_output(num_writers=2)
+        po._queues, po._processes = self._make_queues_and_processes(2)
+        po._writers_running = True
+        po.open(_make_state(4))
+        for q in po._queues:
+            assert q.put.call_count == 1
+            _, msg_type = q.put.call_args.args[0]
+            assert msg_type == MessageType.OPEN
 
 
 class TestParallelOutputWriterAliveCheck:

--- a/tests/unit/outputs/test_parallel.py
+++ b/tests/unit/outputs/test_parallel.py
@@ -505,8 +505,9 @@ class TestChunkerByMetadata:
     def test_result_is_cached(self):
         typed = _make_typed_variables(2, levtype=["sfc", "pl"])
         chunker = Chunker(typed, num_writers=2)
-        first = chunker._grouped_fields_by_metadata(("levtype",))
-        second = chunker._grouped_fields_by_metadata(("levtype",))
+        field_names = ("field_0", "field_1")
+        first = chunker._grouped_fields_by_metadata(field_names, ("levtype",))
+        second = chunker._grouped_fields_by_metadata(field_names, ("levtype",))
         assert first is second
 
 

--- a/tests/unit/outputs/test_time_index.py
+++ b/tests/unit/outputs/test_time_index.py
@@ -239,6 +239,45 @@ class TestNetCDFTimeIndex:
         finally:
             ds.close()
 
+    def test_irregular_cadence(self, tmp_path):
+        """Output dates need not be spaced by output_offsets[0] (e.g. the
+        temporal downscaler emits sub-window steps). The time index must track
+        distinct dates in order regardless of the metadata cadence.
+        """
+        out = self._make_output(tmp_path / "out.nc")
+        step0 = _make_state(0)
+        # irregular, non-uniform spacing that does not match TIMESTEP
+        dates = [
+            START + datetime.timedelta(hours=1),
+            START + datetime.timedelta(hours=1, minutes=37),
+            START + datetime.timedelta(hours=5),
+            START + datetime.timedelta(days=3),
+        ]
+        forecast = []
+        for d in dates:
+            s = _make_state(0)
+            s["date"] = d
+            s["step"] = d - START
+            forecast.append(s)
+
+        out.open(step0)
+        for s in forecast:
+            for chunk in _split_fields(s, 3):
+                out.write_step(chunk)
+        out.close()
+
+        ds = self._read(tmp_path / "out.nc")
+        try:
+            # one dense, gap-free index per distinct date
+            assert ds.dimensions["time"].size == len(forecast)
+            periods = ds.variables["forecast_period"][:]
+            assert list(periods) == [int(s["step"].total_seconds()) for s in forecast]
+            for i, s in enumerate(forecast):
+                for name in ALL_FIELDS:
+                    np.testing.assert_array_equal(ds.variables[name][i], s["fields"][name])
+        finally:
+            ds.close()
+
 
 # ── Zarr ──────────────────────────────────────────────────────────────────────
 

--- a/tests/unit/outputs/test_time_index.py
+++ b/tests/unit/outputs/test_time_index.py
@@ -1,0 +1,361 @@
+# (C) Copyright 2026 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Tests that NetCDF and Zarr outputs compute the time index from the state
+date correctly.
+
+This guarantees that when a single forecast step is delivered through several
+``write_step`` calls (as happens when a parallel output chunk strategy produces
+more chunks than there are writers, so one writer receives several chunks for
+the same step) all the fields for that step land at the same time index, and
+the time coordinate is written correctly.
+
+``open()`` receives the step-zero state (date == forecast start); with
+``write_initial_state`` disabled (the default here) step zero is not written and
+the first forecast step lands at time index 0.
+"""
+
+import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+TIMESTEP = datetime.timedelta(hours=6)
+START = datetime.datetime(2020, 1, 1, 0, 0)
+N_VALUES = 4
+ALL_FIELDS = ["a", "b", "c", "d", "e"]
+
+
+# ── fixtures / helpers ────────────────────────────────────────────────────────
+
+
+def _make_context_and_metadata(*, lead_time=None, multi_step_output=1, write_initial_state=False):
+    context = MagicMock()
+    context.reference_date = START
+    context.typed_variables = {}
+    context.output_frequency = None
+    context.write_initial_state = write_initial_state
+    context.allow_nans = True
+    context.lead_time = lead_time
+
+    output_offsets = [(s + 1) * TIMESTEP for s in range(multi_step_output)]
+
+    metadata = MagicMock()
+    metadata.dataset_name = "test"
+    metadata.typed_variables = {}
+    metadata.output_offsets = output_offsets
+    metadata.rollout_shift = output_offsets[-1]
+    metadata.multi_step_output = multi_step_output
+    return context, metadata
+
+
+def _make_state(step_index, field_names=ALL_FIELDS):
+    """State at forecast ``step_index``. ``step_index == 0`` is step zero
+    (date == forecast start), the state that ``open()`` receives.
+    """
+    date = START + step_index * TIMESTEP
+    return {
+        "date": date,
+        "step": step_index * TIMESTEP,
+        "latitudes": np.arange(N_VALUES, dtype="f4"),
+        "longitudes": np.arange(N_VALUES, dtype="f4"),
+        "fields": {name: np.full(N_VALUES, float(v), dtype="f4") for v, name in enumerate(field_names)},
+    }
+
+
+def _split_fields(state, n_chunks):
+    """Split a state's fields into ``n_chunks`` states (like a chunk strategy)."""
+    names = list(state["fields"])
+    chunks = []
+    for i in range(n_chunks):
+        chunk = dict(state)
+        chunk["fields"] = {name: state["fields"][name] for name in names[i::n_chunks]}
+        chunks.append(chunk)
+    return chunks
+
+
+# ── NetCDF ────────────────────────────────────────────────────────────────────
+
+
+class TestNetCDFTimeIndex:
+    def _make_output(self, path, *, multi_step_output=1, write_initial_state=False):
+        pytest.importorskip("netCDF4")
+        from anemoi.inference.outputs.netcdf import NetCDFOutput
+
+        context, metadata = _make_context_and_metadata(
+            multi_step_output=multi_step_output,
+            write_initial_state=write_initial_state,
+        )
+        return NetCDFOutput(context, metadata, path=str(path))
+
+    def _read(self, path):
+        from netCDF4 import Dataset
+
+        return Dataset(path, "r")
+
+    def test_times_written_at_correct_indices(self, tmp_path):
+        out = self._make_output(tmp_path / "out.nc")
+        step0 = _make_state(0)
+        forecast = [_make_state(i) for i in range(1, 4)]
+        out.open(step0)
+        for s in forecast:
+            out.write_step(s)
+        out.close()
+
+        ds = self._read(tmp_path / "out.nc")
+        try:
+            periods = ds.variables["forecast_period"][:]
+            assert list(periods) == [int(s["step"].total_seconds()) for s in forecast]
+            for i, s in enumerate(forecast):
+                for name in ALL_FIELDS:
+                    np.testing.assert_array_equal(ds.variables[name][i], s["fields"][name])
+        finally:
+            ds.close()
+
+    def test_split_step_lands_on_single_index(self, tmp_path):
+        """A step delivered over several write_step calls must not be scattered."""
+        out = self._make_output(tmp_path / "out.nc")
+        step0 = _make_state(0)
+        forecast = [_make_state(i) for i in range(1, 4)]
+        out.open(step0)
+        for s in forecast:
+            # simulate 3 chunks per step (more chunks than writers -> round robin)
+            for chunk in _split_fields(s, 3):
+                out.write_step(chunk)
+        out.close()
+
+        ds = self._read(tmp_path / "out.nc")
+        try:
+            # exactly one time entry per forecast step (no scattering)
+            assert ds.dimensions["time"].size == len(forecast)
+            periods = ds.variables["forecast_period"][:]
+            assert list(periods) == [int(s["step"].total_seconds()) for s in forecast]
+            for i, s in enumerate(forecast):
+                for name in ALL_FIELDS:
+                    np.testing.assert_array_equal(ds.variables[name][i], s["fields"][name])
+        finally:
+            ds.close()
+
+    def test_split_matches_whole(self, tmp_path):
+        """Writing whole states and split states must produce identical files."""
+        step0 = _make_state(0)
+        forecast = [_make_state(i) for i in range(1, 4)]
+
+        whole = self._make_output(tmp_path / "whole.nc")
+        whole.open(step0)
+        for s in forecast:
+            whole.write_step(s)
+        whole.close()
+
+        split = self._make_output(tmp_path / "split.nc")
+        split.open(step0)
+        for s in forecast:
+            for chunk in _split_fields(s, 3):
+                split.write_step(chunk)
+        split.close()
+
+        a = self._read(tmp_path / "whole.nc")
+        b = self._read(tmp_path / "split.nc")
+        try:
+            np.testing.assert_array_equal(a.variables["forecast_period"][:], b.variables["forecast_period"][:])
+            np.testing.assert_array_equal(a.variables["time"][:], b.variables["time"][:])
+            for name in ALL_FIELDS:
+                np.testing.assert_array_equal(a.variables[name][:], b.variables[name][:])
+        finally:
+            a.close()
+            b.close()
+
+    def test_out_of_order_delivery(self, tmp_path):
+        """Steps delivered out of order still land at the correct index."""
+        out = self._make_output(tmp_path / "out.nc")
+        step0 = _make_state(0)
+        forecast = [_make_state(i) for i in range(1, 4)]
+        out.open(step0)
+        # deliver forecast steps out of order
+        out.write_step(forecast[2])
+        out.write_step(forecast[0])
+        out.write_step(forecast[1])
+        out.close()
+
+        ds = self._read(tmp_path / "out.nc")
+        try:
+            for i, s in enumerate(forecast):
+                for name in ALL_FIELDS:
+                    np.testing.assert_array_equal(ds.variables[name][i], s["fields"][name])
+        finally:
+            ds.close()
+
+    def test_write_step_zero_puts_step0_at_index0(self, tmp_path):
+        """With write_initial_state, step zero is written at index 0."""
+        out = self._make_output(tmp_path / "out.nc", write_initial_state=True)
+        step0 = _make_state(0)
+        forecast = [_make_state(i) for i in range(1, 3)]
+        out.open(step0)
+        out.write_step(step0)  # step zero
+        for s in forecast:
+            out.write_step(s)
+        out.close()
+
+        ds = self._read(tmp_path / "out.nc")
+        try:
+            periods = ds.variables["forecast_period"][:]
+            assert list(periods) == [0] + [int(s["step"].total_seconds()) for s in forecast]
+            all_states = [step0] + forecast
+            for i, s in enumerate(all_states):
+                for name in ALL_FIELDS:
+                    np.testing.assert_array_equal(ds.variables[name][i], s["fields"][name])
+        finally:
+            ds.close()
+
+    def test_multi_step_output_spacing(self, tmp_path):
+        """With multi_step_output > 1 the output offsets are [T, 2T]; the step
+        spacing used for the index must be the smallest offset (T).
+        """
+        out = self._make_output(tmp_path / "out.nc", multi_step_output=2)
+        step0 = _make_state(0)
+        forecast = [_make_state(i) for i in range(1, 5)]
+        out.open(step0)
+        for s in forecast:
+            for chunk in _split_fields(s, 3):
+                out.write_step(chunk)
+        out.close()
+
+        ds = self._read(tmp_path / "out.nc")
+        try:
+            assert ds.dimensions["time"].size == len(forecast)
+            periods = ds.variables["forecast_period"][:]
+            assert list(periods) == [int(s["step"].total_seconds()) for s in forecast]
+            for i, s in enumerate(forecast):
+                for name in ALL_FIELDS:
+                    np.testing.assert_array_equal(ds.variables[name][i], s["fields"][name])
+        finally:
+            ds.close()
+
+
+# ── Zarr ──────────────────────────────────────────────────────────────────────
+
+
+class TestZarrTimeIndex:
+    def _make_output(self, store, *, multi_step_output=1, write_initial_state=False, lead_time=None):
+        pytest.importorskip("zarr")
+        from anemoi.inference.outputs.zarr import ZarrOutput
+
+        context, metadata = _make_context_and_metadata(
+            lead_time=lead_time or 4 * TIMESTEP,
+            multi_step_output=multi_step_output,
+            write_initial_state=write_initial_state,
+        )
+        metadata.typed_variables = {name: SimpleNamespace(grib_keys={"param": name}) for name in ALL_FIELDS}
+        return ZarrOutput(context, metadata, store=str(store))
+
+    def _read(self, store):
+        import zarr
+
+        return zarr.open_group(str(store), mode="r")
+
+    def test_times_written_at_correct_indices(self, tmp_path):
+        store = tmp_path / "out.zarr"
+        out = self._make_output(store)
+        step0 = _make_state(0)
+        forecast = [_make_state(i) for i in range(1, 4)]
+        out.open(step0)
+        for s in forecast:
+            out.write_step(s)
+        out.close()
+
+        g = self._read(store)
+        times = g["time"][:]
+        # time value is (date - reference_date) in seconds; reference_date is
+        # resolved by ZarrOutput.open() from the context / offsets.
+        expected = [int((s["date"] - out.reference_date).total_seconds()) for s in forecast]
+        assert list(times[: len(forecast)]) == expected
+        for i, s in enumerate(forecast):
+            for name in ALL_FIELDS:
+                np.testing.assert_array_equal(g[name][i], s["fields"][name])
+
+    def test_split_step_lands_on_single_index(self, tmp_path):
+        store = tmp_path / "out.zarr"
+        out = self._make_output(store)
+        step0 = _make_state(0)
+        forecast = [_make_state(i) for i in range(1, 4)]
+        out.open(step0)
+        for s in forecast:
+            for chunk in _split_fields(s, 3):
+                out.write_step(chunk)
+        out.close()
+
+        g = self._read(store)
+        times = g["time"][:]
+        expected = [int((s["date"] - out.reference_date).total_seconds()) for s in forecast]
+        # only the first len(forecast) slots are written; the rest stay at fill
+        assert list(times[: len(forecast)]) == expected
+        for i, s in enumerate(forecast):
+            for name in ALL_FIELDS:
+                np.testing.assert_array_equal(g[name][i], s["fields"][name])
+
+    def test_split_matches_whole(self, tmp_path):
+        step0 = _make_state(0)
+        forecast = [_make_state(i) for i in range(1, 4)]
+
+        whole = self._make_output(tmp_path / "whole.zarr")
+        whole.open(step0)
+        for s in forecast:
+            whole.write_step(s)
+        whole.close()
+
+        split = self._make_output(tmp_path / "split.zarr")
+        split.open(step0)
+        for s in forecast:
+            for chunk in _split_fields(s, 3):
+                split.write_step(chunk)
+        split.close()
+
+        a = self._read(tmp_path / "whole.zarr")
+        b = self._read(tmp_path / "split.zarr")
+        np.testing.assert_array_equal(a["time"][:], b["time"][:])
+        for name in ALL_FIELDS:
+            np.testing.assert_array_equal(a[name][:], b[name][:])
+
+    def test_out_of_order_delivery(self, tmp_path):
+        store = tmp_path / "out.zarr"
+        out = self._make_output(store)
+        step0 = _make_state(0)
+        forecast = [_make_state(i) for i in range(1, 4)]
+        out.open(step0)
+        out.write_step(forecast[2])
+        out.write_step(forecast[0])
+        out.write_step(forecast[1])
+        out.close()
+
+        g = self._read(store)
+        for i, s in enumerate(forecast):
+            for name in ALL_FIELDS:
+                np.testing.assert_array_equal(g[name][i], s["fields"][name])
+
+    def test_write_step_zero_puts_step0_at_index0(self, tmp_path):
+        store = tmp_path / "out.zarr"
+        out = self._make_output(store, write_initial_state=True)
+        step0 = _make_state(0)
+        forecast = [_make_state(i) for i in range(1, 3)]
+        out.open(step0)
+        out.write_step(step0)
+        for s in forecast:
+            out.write_step(s)
+        out.close()
+
+        g = self._read(store)
+        all_states = [step0] + forecast
+        times = g["time"][:]
+        expected = [int((s["date"] - out.reference_date).total_seconds()) for s in all_states]
+        assert list(times[: len(all_states)]) == expected
+        for i, s in enumerate(all_states):
+            for name in ALL_FIELDS:
+                np.testing.assert_array_equal(g[name][i], s["fields"][name])


### PR DESCRIPTION
## Description

Adds a configurable **chunking strategy** to the `parallel` output, replacing the previous fixed "split fields evenly across writers" behaviour with a pluggable `Chunker`. This gives users control over *how* output fields are grouped and distributed across writer processes.

The new `chunk_strategy` parameter accepts either a strategy name (string) or a single-key dict of `{strategy: {**kwargs}}`:

- **`by_worker`** (default): splits fields into exactly `num_writers` contiguous chunks, one per writer. Matches the previous behaviour.
- **`by_size`**: fixed-size chunks via `fields_per_chunk`; chunks are dispatched round-robin across writers.
- **`by_metadata`**: groups fields sharing the same metadata `keys` (e.g. `levtype`, `param`, `level`) into the same chunk, with an optional `max_groups` cap that merges groups round-robin.

When a strategy yields more chunks than writers, chunks are assigned round-robin (`chunk i -> writer i % num_writers`).

## What changed

- `src/anemoi/inference/outputs/parallel.py`: new `Chunker` class + `chunk_strategy` config (with validation); `dispatch_state_to_writers` now iterates the chunker and round-robins chunks to writers. Removes the old `_get_state_chunk` helper.
- `tests/unit/outputs/test_parallel.py`: replaced `_get_state_chunk` tests with `Chunker` unit tests (`by_worker`/`by_size`/`by_metadata`, including `max_groups` and caching), added `chunk_strategy` init-validation tests, and dispatch tests covering round-robin distribution. New strategy coverage uses the mocked-queue dispatch path (no forked processes) to keep the suite fast.
- `docs/inference/parallel_output.rst`: documents the new "Chunking Strategies" section with YAML examples for each strategy.

## Testing

`pytest tests/unit/outputs/test_parallel.py` — all tests pass. Docs pass `sphinx-lint` (via pre-commit).

<!-- readthedocs-preview anemoi-inference start -->
----
📚 Documentation preview 📚: https://anemoi-inference--574.org.readthedocs.build/en/574/

<!-- readthedocs-preview anemoi-inference end -->